### PR TITLE
Use `forceX` and `forceY` instead of `forceCenter`

### DIFF
--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -2,7 +2,8 @@ import {
   forceSimulation as d3ForceSimulation,
   forceLink as d3ForceLink,
   forceManyBody as d3ForceManyBody,
-  forceCenter as d3ForceCenter
+  forceX as d3ForceX,
+  forceY as d3ForceY
 } from 'd3-force-3d';
 import { InternalGraphEdge, InternalGraphNode } from 'types';
 import { forceRadial, DagMode } from './forceUtils';
@@ -35,7 +36,8 @@ export function forceDirected({
   const sim = d3ForceSimulation()
     .force('link', d3ForceLink())
     .force('charge', d3ForceManyBody().strength(dimensions > 2 ? -300 : -150))
-    .force('center', d3ForceCenter())
+    .force('x', d3ForceX())
+    .force('y', d3ForceY())
     .force('dagRadial', forceRadial(nodes, links, mode as DagMode))
     .stop();
 

--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -3,7 +3,8 @@ import {
   forceLink as d3ForceLink,
   forceManyBody as d3ForceManyBody,
   forceX as d3ForceX,
-  forceY as d3ForceY
+  forceY as d3ForceY,
+  forceZ as d3ForceZ
 } from 'd3-force-3d';
 import { InternalGraphEdge, InternalGraphNode } from 'types';
 import { forceRadial, DagMode } from './forceUtils';
@@ -34,10 +35,11 @@ export function forceDirected({
 
   // Create the simulation
   const sim = d3ForceSimulation()
+    .force('charge', d3ForceManyBody().strength(dimensions > 2 ? -500 : -250))
     .force('link', d3ForceLink())
-    .force('charge', d3ForceManyBody().strength(dimensions > 2 ? -300 : -150))
     .force('x', d3ForceX())
     .force('y', d3ForceY())
+    .force('z', d3ForceZ())
     .force('dagRadial', forceRadial(nodes, links, mode as DagMode))
     .stop();
 


### PR DESCRIPTION
This seems to work and doesn't seem to be breaking anything else?

### Before:
<img width="868" alt="Screen Shot 2022-05-08 at 18 35 49" src="https://user-images.githubusercontent.com/1086286/167305940-6f964462-dbb8-4d33-ad0b-4fe7f50e6732.png">

### After:
<img width="888" alt="Screen Shot 2022-05-08 at 18 35 35" src="https://user-images.githubusercontent.com/1086286/167305939-b78a6b50-a446-431c-9b64-4b00916aa26b.png">

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
