### PR TITLE
Adds a way to programmatically set camera focus (on one node)

### DIFF
--- a/src/helpers/useSelection.ts
+++ b/src/helpers/useSelection.ts
@@ -95,6 +95,11 @@ export interface SelectionResult {
    * On canvas click event pass through.
    */
   onCanvasClick?: (event: MouseEvent) => void;
+
+  /**
+   * Center the camera on the given node id.
+   */
+  focusOnNode: (value: string) => void;
 }
 
 export const useSelection = ({
@@ -172,6 +177,10 @@ export const useSelection = ({
     clearSelections(path.map(p => p.id as string));
   };
 
+  const focusOnNode = (item: string) => {
+    ref.current?.centerGraph([item]);
+  };
+
   const onKeyDown = (event: KeyboardEvent) => {
     event.preventDefault();
     setMetaKeyDown(event.metaKey || event.ctrlKey);
@@ -239,6 +248,7 @@ export const useSelection = ({
     addSelection,
     removeSelection,
     toggleSelection,
+    focusOnNode,
     setSelections: setInternalSelections
   };
 };


### PR DESCRIPTION
## PR Type
```
[x] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently there's no way to programmatically set the camera focus, so setting selection via click can do more than setting selection elsewhere.

Issue Number: https://github.com/reaviz/reagraph/issues/27


## What is the new behavior?

Adds a `focusOnNode` method to the `useSelection` hook, allowing focus to be set externally.
I considered having the `setSelection`,  `addSelection` etc methods check `focusOnSelect` within themselves but that was a bigger change than I wanted to make ( though if you want to do that instead feel free to go down that route & close this PR).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
