### PR TITLE
Set `DoubleSide` on the arrow heads

### DIFF
--- a/src/symbols/Arrow.tsx
+++ b/src/symbols/Arrow.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo, useRef, useEffect, useCallback } from 'react';
 import { useSpring, a } from '@react-spring/three';
-import { Color, ColorRepresentation, Mesh } from 'three';
+import { Color, ColorRepresentation, Mesh, DoubleSide } from 'three';
 import {
   getQuaternion,
   animationConfig,
@@ -83,6 +83,7 @@ export const Arrow: FC<ArrowProps> = ({
         depthTest={false}
         opacity={arrowOpacity}
         transparent={true}
+        side={DoubleSide}
         fog={true}
       />
     </a.mesh>


### PR DESCRIPTION
Before:
![Screenshot 2022-07-17 at 19 10 15](https://user-images.githubusercontent.com/2095051/179419230-eb492f0a-86eb-4b0a-be74-3363b28f55db.png)
After:
![Screenshot 2022-07-17 at 19 10 01](https://user-images.githubusercontent.com/2095051/179419234-3beaff54-92a8-4511-9a47-659175d9d6c7.png)

- Prevents the gap, but I'm not convinced it's the best solution (maybe the line should extend into the arrow instead?)
