### PR TITLE
maintain internal graph state for hidden nodes/edges

### DIFF
--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -229,8 +229,8 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
 
       const [graph, nodes, edges] = useStore(state => [
         state.graph,
-        state.nodes,
-        state.edges
+        state.internalNodes,
+        state.internalEdges
       ]);
 
       const nodeIds = useMemo(() => nodes.map(n => n.id), [nodes]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,7 +16,6 @@ export interface GraphState {
   internalNodes: InternalGraphNode[];
   internalEdges: InternalGraphEdge[];
   graph: Graph;
-  fullGraph: Graph;
   collapsedNodeIds?: string[];
   selections?: string[];
   actives?: string[];
@@ -51,7 +50,6 @@ export const createStore = () =>
     actives: [],
     drags: {},
     graph: ngraph(),
-    fullGraph: ngraph(),
     setPanning: panning => set(state => ({ ...state, panning })),
     setDrags: drags => set(state => ({ ...state, drags })),
     setDraggingId: draggingId => set(state => ({ ...state, draggingId })),
@@ -83,8 +81,7 @@ export const createStore = () =>
           getUpdatedCollapsedState({
             nodeIds,
             nodes: [...state.nodes],
-            edges: [...state.edges],
-            graph: state.fullGraph
+            edges: [...state.edges]
           });
         return {
           ...state,

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -55,11 +55,15 @@ export const Edge: FC<EdgeProps> = ({
   onPointerOver,
   onPointerOut
 }) => {
-  const edge = useStore(state => state.edges.find(e => e.id === id));
+  const edge = useStore(state => state.internalEdges.find(e => e.id === id));
   const { toId, fromId, label, labelVisible = false, hidden, size = 1 } = edge;
 
-  const from = useStore(store => store.nodes.find(node => node.id === fromId));
-  const to = useStore(store => store.nodes.find(node => node.id === toId));
+  const from = useStore(store =>
+    store.internalNodes.find(node => node.id === fromId)
+  );
+  const to = useStore(store =>
+    store.internalNodes.find(node => node.id === toId)
+  );
   const draggingId = useStore(state => state.draggingId);
   const [active, setActive] = useState<boolean>(false);
   const [menuVisible, setMenuVisible] = useState<boolean>(false);

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -64,7 +64,7 @@ export const Node: FC<NodeProps> = ({
   const node = useStore(state => state.internalNodes.find(n => n.id === id));
 
   const [
-    fullGraph,
+    edges,
     draggingId,
     collapsedNodeIds,
     setDraggingId,
@@ -72,7 +72,7 @@ export const Node: FC<NodeProps> = ({
     setCollapsedNodeIds,
     isCollapsed
   ] = useStore(state => [
-    state.fullGraph,
+    state.edges,
     state.draggingId,
     state.collapsedNodeIds,
     state.setDraggingId,
@@ -109,13 +109,10 @@ export const Node: FC<NodeProps> = ({
 
   const canCollapse = useMemo(() => {
     // If the node has outgoing edges, it can collapse via context menu
-    const links = fullGraph.getLinks(id);
-    const outboundLinks = links
-      ? [...links].filter(l => l.data.source === id)
-      : [];
+    const outboundLinks = edges.filter(l => l.data.source === id);
 
     return outboundLinks.length > 0;
-  }, [fullGraph, id]);
+  }, [edges, id]);
 
   const onCollapse = useCallback(() => {
     if (canCollapse) {

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -61,10 +61,10 @@ export const Node: FC<NodeProps> = ({
   renderNode
 }) => {
   const cameraControls = useCameraControls();
-  const node = useStore(state => state.nodes.find(n => n.id === id));
+  const node = useStore(state => state.internalNodes.find(n => n.id === id));
 
   const [
-    graph,
+    fullGraph,
     draggingId,
     collapsedNodeIds,
     setDraggingId,
@@ -72,7 +72,7 @@ export const Node: FC<NodeProps> = ({
     setCollapsedNodeIds,
     isCollapsed
   ] = useStore(state => [
-    state.graph,
+    state.fullGraph,
     state.draggingId,
     state.collapsedNodeIds,
     state.setDraggingId,
@@ -109,13 +109,13 @@ export const Node: FC<NodeProps> = ({
 
   const canCollapse = useMemo(() => {
     // If the node has outgoing edges, it can collapse via context menu
-    const links = graph.getLinks(id);
+    const links = fullGraph.getLinks(id);
     const outboundLinks = links
       ? [...links].filter(l => l.data.source === id)
       : [];
 
     return outboundLinks.length > 0;
-  }, [graph, id]);
+  }, [fullGraph, id]);
 
   const onCollapse = useCallback(() => {
     if (canCollapse) {

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -47,7 +47,6 @@ export const useGraph = ({
 }: GraphInputs) => {
   const [
     graph,
-    fullGraph,
     internalNodes,
     internalEdges,
     stateCollapsedNodeIds,
@@ -62,7 +61,6 @@ export const useGraph = ({
     setCollapsedNodeIds
   ] = useStore(state => [
     state.graph,
-    state.fullGraph,
     state.internalNodes,
     state.internalEdges,
     state.collapsedNodeIds,
@@ -153,7 +151,6 @@ export const useGraph = ({
   useEffect(() => {
     layoutMounted.current = false;
     buildGraph(graph, nodes, edges);
-    buildGraph(fullGraph, nodes, edges);
     updateLayout();
 
     // queue this in a frame so it only happens after the graph is built
@@ -164,7 +161,7 @@ export const useGraph = ({
     });
 
     // eslint-disable-next-line
-  }, [nodes, edges, graph, fullGraph]);
+  }, [nodes, edges, graph]);
 
   useEffect(() => {
     // Let's set the store collapsedNodeIds so its easier to access

--- a/src/utils/buildGraph.ts
+++ b/src/utils/buildGraph.ts
@@ -93,7 +93,9 @@ export function transformGraph({
       };
 
       map.set(node.id, n);
-      nodes.push(n);
+      if (!hidden) {
+        nodes.push(n);
+      }
     }
   });
 
@@ -105,19 +107,21 @@ export function transformGraph({
       const { data, id, label, size, hidden, ...rest } = link.data;
       const labelVisible = checkVisibility('edge', link.size);
 
-      edges.push({
-        ...link,
-        id,
-        label,
-        labelVisible,
-        size,
-        hidden,
-        data: {
-          ...rest,
+      if (!hidden) {
+        edges.push({
+          ...link,
           id,
-          ...(data || {})
-        }
-      });
+          label,
+          labelVisible,
+          size,
+          hidden,
+          data: {
+            ...rest,
+            id,
+            ...(data || {})
+          }
+        });
+      }
     }
   });
 

--- a/src/utils/collapse.ts
+++ b/src/utils/collapse.ts
@@ -51,7 +51,7 @@ export const getUpdatedCollapsedState = ({
   const curHiddenNodeIds = [];
 
   for (const collapsedId of collapsedNodeIds) {
-    const nodeLinks = graph.getLinks(collapsedId);
+    const nodeLinks = graph.getLinks(collapsedId) || [];
     const outboundEdges = [...nodeLinks].filter(
       l => l.data.source === collapsedId
     );
@@ -87,7 +87,7 @@ export const getUpdatedCollapsedState = ({
       }
 
       // Determine if there is another edge going to this node
-      const curNodeLinks = graph.getLinks(n.id);
+      const curNodeLinks = graph.getLinks(n.id) || [];
       const inboundNodeLinks = [...curNodeLinks].filter(
         l => l.data.target === n.id
       );
@@ -116,8 +116,8 @@ export const getUpdatedCollapsedState = ({
   }
 
   return {
-    updatedEdges,
-    updatedNodes,
+    updatedEdges: updatedEdges.filter(e => !e.hidden),
+    updatedNodes: updatedNodes.filter(n => !n.hidden),
     collapsedNodeIds
   };
 };

--- a/src/utils/collapse.ts
+++ b/src/utils/collapse.ts
@@ -5,7 +5,6 @@ interface UpdateCollapsedStateInput {
   nodeIds: string[];
   nodes: InternalGraphNode[];
   edges: InternalGraphEdge[];
-  graph: Graph;
 }
 
 function getNestedParents(nodeId: string, nodes: InternalGraphNode[]) {
@@ -24,8 +23,7 @@ function getNestedParents(nodeId: string, nodes: InternalGraphNode[]) {
 export const getUpdatedCollapsedState = ({
   nodeIds,
   nodes,
-  edges,
-  graph
+  edges
 }: UpdateCollapsedStateInput) => {
   let collapsedNodeIds = [];
 
@@ -51,10 +49,7 @@ export const getUpdatedCollapsedState = ({
   const curHiddenNodeIds = [];
 
   for (const collapsedId of collapsedNodeIds) {
-    const nodeLinks = graph.getLinks(collapsedId) || [];
-    const outboundEdges = [...nodeLinks].filter(
-      l => l.data.source === collapsedId
-    );
+    const outboundEdges = edges.filter(l => l.data.source === collapsedId);
     const outboundEdgeIds = outboundEdges.map(l => l.data.id);
     const outboundEdgeNodeIds = outboundEdges.map(l => l.data.target);
 
@@ -87,10 +82,7 @@ export const getUpdatedCollapsedState = ({
       }
 
       // Determine if there is another edge going to this node
-      const curNodeLinks = graph.getLinks(n.id) || [];
-      const inboundNodeLinks = [...curNodeLinks].filter(
-        l => l.data.target === n.id
-      );
+      const inboundNodeLinks = edges.filter(l => l.data.target === n.id);
 
       if (inboundNodeLinks.length > 1 && !curHiddenNodeIds.includes(n.id)) {
         // If all inbound links are hidden, hide this node as well


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Nodes/edges are hidden from the graph but are only hidden visually. Since they are still part of the graph, they are taken into account with zoom/node locations
Issue Number: N/A


## What is the new behavior?
Maintain an internal/external graph and node/edge state. The internal state will house what is being rendered on the graph while the external state maintains the full list of passed in nodes/edges. These states allow the graph to determine links between hidden nodes/edges

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other in

https://user-images.githubusercontent.com/6655992/189459643-40bc24b5-c1f9-411d-b758-36d635e475bc.mov

formation
