### PR TITLE
Collapsible refactor

### DIFF
--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -224,13 +224,9 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       },
       ref
     ) => {
-      const { mounted } = useGraph(rest);
+      const { mounted, visibleEdgeIds, visibleNodeIds } = useGraph(rest);
 
-      const [graph, nodeIds, edgeIds] = useStore(state => [
-        state.graph,
-        state.nodes.map(n => n.id),
-        state.edges.map(e => e.id)
-      ]);
+      const [graph] = useStore(state => [state.graph]);
 
       const { centerNodesById } = useCenterGraph({
         animated
@@ -249,7 +245,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
         <Fragment>
           {mounted && (
             <Fragment>
-              {nodeIds.map(n => (
+              {visibleNodeIds.map(n => (
                 <Node
                   key={n}
                   id={n}
@@ -266,7 +262,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
                   renderNode={renderNode}
                 />
               ))}
-              {edgeIds.map(e => (
+              {visibleEdgeIds.map(e => (
                 <Edge
                   theme={theme}
                   key={e}

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -3,7 +3,8 @@ import React, {
   forwardRef,
   Fragment,
   Ref,
-  useImperativeHandle
+  useImperativeHandle,
+  useMemo
 } from 'react';
 import { useGraph } from './useGraph';
 import { LayoutOverrides, LayoutTypes } from './layout';
@@ -224,9 +225,15 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       },
       ref
     ) => {
-      const { mounted, visibleEdgeIds, visibleNodeIds } = useGraph(rest);
+      const { mounted } = useGraph(rest);
 
-      const [graph] = useStore(state => [state.graph]);
+      const [graph, nodes, edges] = useStore(state => [
+        state.graph,
+        state.nodes,
+        state.edges
+      ]);
+      const nodeIds = useMemo(() => nodes.map(n => n.id), [nodes]);
+      const edgeIds = useMemo(() => edges.map(e => e.id), [edges]);
 
       const { centerNodesById } = useCenterGraph({
         animated
@@ -245,7 +252,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
         <Fragment>
           {mounted && (
             <Fragment>
-              {visibleNodeIds.map(n => (
+              {nodeIds.map(n => (
                 <Node
                   key={n}
                   id={n}
@@ -262,7 +269,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
                   renderNode={renderNode}
                 />
               ))}
-              {visibleEdgeIds.map(e => (
+              {edgeIds.map(e => (
                 <Edge
                   theme={theme}
                   key={e}

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -228,8 +228,8 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
 
       const [graph, nodeIds, edgeIds] = useStore(state => [
         state.graph,
-        state.internalNodes.map(n => n.id),
-        state.internalEdges.map(e => e.id)
+        state.nodes.map(n => n.id),
+        state.edges.map(e => e.id)
       ]);
 
       const { centerNodesById } = useCenterGraph({

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,8 +13,6 @@ export type DragReferences = { [key: string]: InternalGraphNode };
 export interface GraphState {
   nodes: InternalGraphNode[];
   edges: InternalGraphEdge[];
-  internalNodes: InternalGraphNode[];
-  internalEdges: InternalGraphEdge[];
   graph: Graph;
   collapsedNodeIds?: string[];
   selections?: string[];
@@ -29,8 +27,6 @@ export interface GraphState {
   setSelections: (selections: string[]) => void;
   setNodes: (nodes: InternalGraphNode[]) => void;
   setEdges: (edges: InternalGraphEdge[]) => void;
-  setInternalNodes: (nodes: InternalGraphNode[]) => void;
-  setInternalEdges: (edges: InternalGraphEdge[]) => void;
   setNodePosition: (id: string, position: InternalGraphPosition) => void;
   setCollapsedNodeIds: (nodeIds: string[]) => void;
 }
@@ -45,8 +41,6 @@ export const createStore = ({
   create<GraphState>(set => ({
     edges: [],
     nodes: [],
-    internalEdges: [],
-    internalNodes: [],
     collapsedNodeIds,
     panning: false,
     draggingId: null,
@@ -61,22 +55,15 @@ export const createStore = ({
     setSelections: selections => set(state => ({ ...state, selections })),
     setNodes: nodes => set(state => ({ ...state, nodes })),
     setEdges: edges => set(state => ({ ...state, edges })),
-    setInternalNodes: nodes =>
-      set(state => ({ ...state, internalNodes: nodes.filter(n => !n.hidden) })),
-    setInternalEdges: edges =>
-      set(state => ({ ...state, internalEdges: edges.filter(e => !e.hidden) })),
     setNodePosition: (id, position) =>
       set(state => {
-        const node = state.internalNodes.find(n => n.id === id);
+        const node = state.nodes.find(n => n.id === id);
         // TODO: Come back and fix this so we don't have to double project
         const newNode = { ...node, ...position, position };
         return {
           ...state,
           drags: { ...state.drags, [id]: newNode },
-          internalNodes: [
-            ...state.internalNodes.filter(n => n.id !== id),
-            newNode
-          ]
+          nodes: [...state.nodes.filter(n => n.id !== id), newNode]
         };
       }),
     setCollapsedNodeIds: (nodeIds = []) =>
@@ -89,8 +76,8 @@ export const createStore = ({
           });
         return {
           ...state,
-          internalEdges: updatedEdges,
-          internalNodes: updatedNodes,
+          edges: updatedEdges,
+          nodes: updatedNodes,
           collapsedNodeIds
         };
       })

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,7 +6,6 @@ import {
   InternalGraphPosition
 } from './types';
 import ngraph, { Graph } from 'ngraph.graph';
-import { getUpdatedCollapsedState } from './utils/collapse';
 
 export type DragReferences = { [key: string]: InternalGraphNode };
 
@@ -67,18 +66,5 @@ export const createStore = ({
         };
       }),
     setCollapsedNodeIds: (nodeIds = []) =>
-      set(state => {
-        const { updatedNodes, updatedEdges, collapsedNodeIds } =
-          getUpdatedCollapsedState({
-            nodeIds,
-            nodes: [...state.nodes],
-            edges: [...state.edges]
-          });
-        return {
-          ...state,
-          edges: updatedEdges,
-          nodes: updatedNodes,
-          collapsedNodeIds
-        };
-      })
+      set(state => ({ ...state, collapsedNodeIds: nodeIds }))
   }));

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -55,15 +55,11 @@ export const Edge: FC<EdgeProps> = ({
   onPointerOver,
   onPointerOut
 }) => {
-  const edge = useStore(state => state.internalEdges.find(e => e.id === id));
+  const edge = useStore(state => state.edges.find(e => e.id === id));
   const { toId, fromId, label, labelVisible = false, size = 1 } = edge;
 
-  const from = useStore(store =>
-    store.internalNodes.find(node => node.id === fromId)
-  );
-  const to = useStore(store =>
-    store.internalNodes.find(node => node.id === toId)
-  );
+  const from = useStore(store => store.nodes.find(node => node.id === fromId));
+  const to = useStore(store => store.nodes.find(node => node.id === toId));
   const draggingId = useStore(state => state.draggingId);
   const [active, setActive] = useState<boolean>(false);
   const [menuVisible, setMenuVisible] = useState<boolean>(false);

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -104,8 +104,8 @@ export const Node: FC<NodeProps> = ({
     // If the node has outgoing edges, it can collapse via context menu
     const outboundLinks = edges.filter(l => l.data.source === id);
 
-    return outboundLinks.length > 0;
-  }, [edges, id]);
+    return outboundLinks.length > 0 || isCollapsed;
+  }, [edges, id, isCollapsed]);
 
   const onCollapse = useCallback(() => {
     if (canCollapse) {

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -61,7 +61,7 @@ export const Node: FC<NodeProps> = ({
   renderNode
 }) => {
   const cameraControls = useCameraControls();
-  const node = useStore(state => state.internalNodes.find(n => n.id === id));
+  const node = useStore(state => state.nodes.find(n => n.id === id));
 
   const [
     edges,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,11 +35,6 @@ export interface GraphNode extends GraphElementBaseAttributes {
   parents?: string[];
 
   /**
-   * Whether the node is hidden after being collapsed
-   */
-  hidden?: boolean;
-
-  /**
    * Icon URL for the node.
    */
   icon?: string;
@@ -60,11 +55,6 @@ export interface GraphEdge extends GraphElementBaseAttributes {
    * Target ID of the node.
    */
   target: string;
-
-  /**
-   * Whether the edge is hidden after being collapsed
-   */
-  hidden?: boolean;
 }
 
 export interface Graph {

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { SizingType } from './sizing';
 import {
   LayoutTypes,
@@ -11,6 +11,7 @@ import { tick } from './layout/layoutUtils';
 import { GraphEdge, GraphNode } from './types';
 import { buildGraph, transformGraph } from './utils/buildGraph';
 import { DragReferences, useStore } from './store';
+import { getVisibleEntities } from './utils/collapse';
 
 export interface GraphInputs {
   nodes: GraphNode[];
@@ -74,6 +75,18 @@ export const useGraph = ({
   const [mounted, setMounted] = useState<boolean>(false);
   const layoutMounted = useRef<boolean>(false);
   const layout = useRef<LayoutStrategy | null>(null);
+  const { visibleEdgeIds, visibleNodeIds } = useMemo(() => {
+    const { visibleEdges, visibleNodes } = getVisibleEntities({
+      collapsedIds: stateCollapsedNodeIds,
+      nodes: stateNodes,
+      edges: stateEdges
+    });
+
+    return {
+      visibleEdgeIds: visibleEdges.map(e => e.id),
+      visibleNodeIds: visibleNodes.map(n => n.id)
+    };
+  }, [stateCollapsedNodeIds, stateNodes, stateEdges]);
 
   // Transient updates
   const dragRef = useRef<DragReferences>(drags);
@@ -194,6 +207,8 @@ export const useGraph = ({
   }, [graph, sizingType, sizingAttribute, labelType, updateLayout]);
 
   return {
-    mounted
+    mounted,
+    visibleEdgeIds,
+    visibleNodeIds
   };
 };

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -48,8 +48,6 @@ export const useGraph = ({
 }: GraphInputs) => {
   const [
     graph,
-    stateNodes,
-    stateEdges,
     stateCollapsedNodeIds,
     setEdges,
     setNodes,
@@ -60,8 +58,6 @@ export const useGraph = ({
     setCollapsedNodeIds
   ] = useStore(state => [
     state.graph,
-    state.nodes,
-    state.edges,
     state.collapsedNodeIds,
     state.setEdges,
     state.setNodes,
@@ -75,18 +71,18 @@ export const useGraph = ({
   const [mounted, setMounted] = useState<boolean>(false);
   const layoutMounted = useRef<boolean>(false);
   const layout = useRef<LayoutStrategy | null>(null);
-  const { visibleEdgeIds, visibleNodeIds } = useMemo(() => {
+  const { visibleEdges, visibleNodes } = useMemo(() => {
     const { visibleEdges, visibleNodes } = getVisibleEntities({
       collapsedIds: stateCollapsedNodeIds,
-      nodes: stateNodes,
-      edges: stateEdges
+      nodes,
+      edges
     });
 
     return {
-      visibleEdgeIds: visibleEdges.map(e => e.id),
-      visibleNodeIds: visibleNodes.map(n => n.id)
+      visibleEdges,
+      visibleNodes
     };
-  }, [stateCollapsedNodeIds, stateNodes, stateEdges]);
+  }, [stateCollapsedNodeIds, nodes, edges]);
 
   // Transient updates
   const dragRef = useRef<DragReferences>(drags);
@@ -151,7 +147,7 @@ export const useGraph = ({
   // Create the nggraph graph object
   useEffect(() => {
     layoutMounted.current = false;
-    buildGraph(graph, nodes, edges);
+    buildGraph(graph, visibleNodes, visibleEdges);
     updateLayout();
 
     // queue this in a frame so it only happens after the graph is built
@@ -162,29 +158,12 @@ export const useGraph = ({
     });
 
     // eslint-disable-next-line
-  }, [nodes, edges, graph]);
+  }, [visibleNodes, visibleEdges, graph]);
 
   useEffect(() => {
     // Let's set the store collapsedNodeIds so its easier to access
     setCollapsedNodeIds(collapsedNodeIds);
   }, [collapsedNodeIds, setCollapsedNodeIds]);
-
-  useEffect(() => {
-    if (mounted) {
-      // Update the layout of the graph when nodes are expanded/collapsed
-      const graphEdges = stateEdges.map(e => ({
-        ...e,
-        source: e.fromId,
-        target: e.toId,
-        fromId: undefined,
-        toId: undefined
-      }));
-
-      buildGraph(graph, stateNodes, graphEdges);
-      updateLayout();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mounted, stateCollapsedNodeIds]);
 
   // Update layout on type changes
   useEffect(() => {
@@ -207,8 +186,6 @@ export const useGraph = ({
   }, [graph, sizingType, sizingAttribute, labelType, updateLayout]);
 
   return {
-    mounted,
-    visibleEdgeIds,
-    visibleNodeIds
+    mounted
   };
 };

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -47,11 +47,9 @@ export const useGraph = ({
 }: GraphInputs) => {
   const [
     graph,
-    internalNodes,
-    internalEdges,
+    stateNodes,
+    stateEdges,
     stateCollapsedNodeIds,
-    setInternalEdges,
-    setInternalNodes,
     setEdges,
     setNodes,
     setSelections,
@@ -61,11 +59,9 @@ export const useGraph = ({
     setCollapsedNodeIds
   ] = useStore(state => [
     state.graph,
-    state.internalNodes,
-    state.internalEdges,
+    state.nodes,
+    state.edges,
     state.collapsedNodeIds,
-    state.setInternalEdges,
-    state.setInternalNodes,
     state.setEdges,
     state.setNodes,
     state.setSelections,
@@ -109,13 +105,8 @@ export const useGraph = ({
           defaultNodeSize
         });
 
-        if (layoutMounted.current) {
-          setInternalEdges(result.edges);
-          setInternalNodes(result.nodes);
-        } else {
-          setEdges(result.edges);
-          setNodes(result.nodes);
-        }
+        setEdges(result.edges);
+        setNodes(result.nodes);
       });
     },
     [
@@ -129,9 +120,6 @@ export const useGraph = ({
       maxNodeSize,
       minNodeSize,
       defaultNodeSize,
-      layoutMounted,
-      setInternalEdges,
-      setInternalNodes,
       setEdges,
       setNodes
     ]
@@ -171,7 +159,7 @@ export const useGraph = ({
   useEffect(() => {
     if (mounted) {
       // Update the layout of the graph when nodes are expanded/collapsed
-      const graphEdges = internalEdges.map(e => ({
+      const graphEdges = stateEdges.map(e => ({
         ...e,
         source: e.fromId,
         target: e.toId,
@@ -179,7 +167,7 @@ export const useGraph = ({
         toId: undefined
       }));
 
-      buildGraph(graph, internalNodes, graphEdges);
+      buildGraph(graph, stateNodes, graphEdges);
       updateLayout();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/utils/buildGraph.ts
+++ b/src/utils/buildGraph.ts
@@ -66,7 +66,7 @@ export function transformGraph({
   graph.forEachNode((node: any) => {
     if (node.data) {
       const position = layout.getNodePosition(node.id);
-      const { data, fill, icon, label, size, hidden, ...rest } = node.data;
+      const { data, fill, icon, label, size, ...rest } = node.data;
       const nodeSize = sizes.get(node.id);
       const labelVisible = checkVisibility('node', nodeSize);
       const nodeLinks = graph.getLinks(node.id);
@@ -81,7 +81,6 @@ export function transformGraph({
         icon,
         fill,
         parents,
-        hidden,
         data: {
           ...rest,
           ...(data || {})
@@ -93,9 +92,7 @@ export function transformGraph({
       };
 
       map.set(node.id, n);
-      if (!hidden) {
-        nodes.push(n);
-      }
+      nodes.push(n);
     }
   });
 
@@ -104,24 +101,21 @@ export function transformGraph({
     const to = map.get(link.toId);
 
     if (from && to) {
-      const { data, id, label, size, hidden, ...rest } = link.data;
+      const { data, id, label, size, ...rest } = link.data;
       const labelVisible = checkVisibility('edge', link.size);
 
-      if (!hidden) {
-        edges.push({
-          ...link,
+      edges.push({
+        ...link,
+        id,
+        label,
+        labelVisible,
+        size,
+        data: {
+          ...rest,
           id,
-          label,
-          labelVisible,
-          size,
-          hidden,
-          data: {
-            ...rest,
-            id,
-            ...(data || {})
-          }
-        });
-      }
+          ...(data || {})
+        }
+      });
     }
   });
 

--- a/src/utils/collapse.ts
+++ b/src/utils/collapse.ts
@@ -1,4 +1,4 @@
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import { GraphEdge, GraphNode } from '../types';
 
 interface GetHiddenChildrenInput {

--- a/src/utils/collapse.ts
+++ b/src/utils/collapse.ts
@@ -1,115 +1,106 @@
-import { Graph } from 'ngraph.graph';
+import { uniqBy } from 'lodash';
 import { InternalGraphEdge, InternalGraphNode } from '../types';
 
-interface UpdateCollapsedStateInput {
-  nodeIds: string[];
+interface GetHiddenChildrenInput {
+  nodeId: string;
+  nodes: InternalGraphNode[];
+  edges: InternalGraphEdge[];
+  currentHiddenNodes: InternalGraphNode[];
+  currentHiddenEdges: InternalGraphEdge[];
+}
+
+interface GetVisibleIdsInput {
+  collapsedIds: string[];
   nodes: InternalGraphNode[];
   edges: InternalGraphEdge[];
 }
 
-function getNestedParents(nodeId: string, nodes: InternalGraphNode[]) {
-  const parentNodeIds = [];
-  const childNodes = nodes.filter(n => n.parents?.includes(nodeId));
-  if (childNodes.length > 0) {
-    parentNodeIds.push(nodeId);
-    for (const child of childNodes) {
-      parentNodeIds.push(...getNestedParents(child.id, nodes));
+function getHiddenChildren({
+  nodeId,
+  nodes,
+  edges,
+  currentHiddenNodes,
+  currentHiddenEdges
+}: GetHiddenChildrenInput) {
+  const hiddenNodes: InternalGraphNode[] = [];
+  const hiddenEdges: InternalGraphEdge[] = [];
+  const curHiddenNodeIds = currentHiddenNodes.map(n => n.id);
+  const curHiddenEdgeIds = currentHiddenEdges.map(e => e.id);
+
+  const outboundEdges = edges.filter(l => l.data.source === nodeId);
+  const outboundEdgeNodeIds = outboundEdges.map(l => l.data.target);
+
+  hiddenEdges.push(...outboundEdges);
+  for (const outboundEdgeNodeId of outboundEdgeNodeIds) {
+    const incomingEdges = edges.filter(
+      l => l.data.target === outboundEdgeNodeId && l.data.source !== nodeId
+    );
+    let hideNode = false;
+
+    // Check to see if any other edge is coming into this node
+    if (incomingEdges.length === 0) {
+      hideNode = true;
+    } else if (
+      incomingEdges.length > 0 &&
+      !curHiddenNodeIds.includes(outboundEdgeNodeId)
+    ) {
+      // If all inbound links are hidden, hide this node as well
+      const inboundNodeLinkIds = incomingEdges.map(l => l.data.id);
+      if (inboundNodeLinkIds.every(i => curHiddenEdgeIds.includes(i))) {
+        hideNode = true;
+      }
+    }
+    if (hideNode) {
+      // Need to hide this node and any children of this node
+      const node = nodes.find(n => n.id === outboundEdgeNodeId);
+      if (node) {
+        hiddenNodes.push(node);
+      }
+      const nested = getHiddenChildren({
+        nodeId: outboundEdgeNodeId,
+        nodes,
+        edges,
+        currentHiddenEdges,
+        currentHiddenNodes
+      });
+      hiddenEdges.push(...nested.hiddenEdges);
+      hiddenNodes.push(...nested.hiddenNodes);
     }
   }
 
-  return parentNodeIds;
+  return {
+    hiddenEdges: uniqBy(hiddenEdges, 'id'),
+    hiddenNodes: uniqBy(hiddenNodes, 'id')
+  };
 }
 
-export const getUpdatedCollapsedState = ({
-  nodeIds,
+export const getVisibleEntities = ({
+  collapsedIds,
   nodes,
   edges
-}: UpdateCollapsedStateInput) => {
-  let collapsedNodeIds = [];
+}: GetVisibleIdsInput) => {
+  const curHiddenNodes = [];
+  const curHiddenEdges = [];
 
-  // Add any node ids that are nested parents that had their parent collapsed
-  // ie gradparent -> parent -> node and grandparent was collapsed
-  for (const collapsedId of nodeIds) {
-    collapsedNodeIds.push(...getNestedParents(collapsedId, nodes));
+  for (const collapsedId of collapsedIds) {
+    const { hiddenEdges, hiddenNodes } = getHiddenChildren({
+      nodeId: collapsedId,
+      nodes,
+      edges,
+      currentHiddenEdges: curHiddenEdges,
+      currentHiddenNodes: curHiddenNodes
+    });
+    curHiddenNodes.push(...hiddenNodes);
+    curHiddenEdges.push(...hiddenEdges);
   }
 
-  // Reset hidden state of edges/nodes
-  let updatedEdges = edges.map(e => ({
-    ...e,
-    hidden: false
-  }));
-
-  let updatedNodes = nodes.map(n => ({
-    ...n,
-    hidden: false
-  }));
-
-  // Keep track of which edges and nodes were hidden from this change
-  const curHiddenEdgeIds = [];
-  const curHiddenNodeIds = [];
-
-  for (const collapsedId of collapsedNodeIds) {
-    const outboundEdges = edges.filter(l => l.data.source === collapsedId);
-    const outboundEdgeIds = outboundEdges.map(l => l.data.id);
-    const outboundEdgeNodeIds = outboundEdges.map(l => l.data.target);
-
-    updatedEdges = updatedEdges.map(e => {
-      if (outboundEdgeIds.includes(e.id)) {
-        curHiddenEdgeIds.push(e.id);
-        return {
-          ...e,
-          hidden: true
-        };
-      } else if (curHiddenEdgeIds.includes(e.id)) {
-        return e;
-      }
-
-      return {
-        ...e,
-        hidden: false
-      };
-    });
-
-    updatedNodes = updatedNodes.map(n => {
-      if (
-        !outboundEdgeNodeIds.includes(n.id) &&
-        !curHiddenNodeIds.includes(n.id)
-      ) {
-        return {
-          ...n,
-          hidden: false
-        };
-      }
-
-      // Determine if there is another edge going to this node
-      const inboundNodeLinks = edges.filter(l => l.data.target === n.id);
-
-      if (inboundNodeLinks.length > 1 && !curHiddenNodeIds.includes(n.id)) {
-        // If all inbound links are hidden, hide this node as well
-        const inboundNodeLinkIds = inboundNodeLinks.map(l => l.data.id);
-        if (!inboundNodeLinkIds.every(i => curHiddenEdgeIds.includes(i))) {
-          return {
-            ...n,
-            hidden: false
-          };
-        }
-      }
-
-      if (!curHiddenNodeIds.includes(n.id)) {
-        curHiddenNodeIds.push(n.id);
-        return {
-          ...n,
-          hidden: true
-        };
-      }
-
-      return n;
-    });
-  }
+  const hiddenNodeIds = curHiddenNodes.map(n => n.id);
+  const hiddenEdgeIds = curHiddenEdges.map(e => e.id);
+  const visibleNodes = nodes.filter(n => !hiddenNodeIds.includes(n.id));
+  const visibleEdges = edges.filter(e => !hiddenEdgeIds.includes(e.id));
 
   return {
-    updatedEdges: updatedEdges.filter(e => !e.hidden),
-    updatedNodes: updatedNodes.filter(n => !n.hidden),
-    collapsedNodeIds
+    visibleNodes,
+    visibleEdges
   };
 };

--- a/src/utils/collapse.ts
+++ b/src/utils/collapse.ts
@@ -1,18 +1,18 @@
 import { uniqBy } from 'lodash';
-import { InternalGraphEdge, InternalGraphNode } from '../types';
+import { GraphEdge, GraphNode } from '../types';
 
 interface GetHiddenChildrenInput {
   nodeId: string;
-  nodes: InternalGraphNode[];
-  edges: InternalGraphEdge[];
-  currentHiddenNodes: InternalGraphNode[];
-  currentHiddenEdges: InternalGraphEdge[];
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  currentHiddenNodes: GraphNode[];
+  currentHiddenEdges: GraphEdge[];
 }
 
 interface GetVisibleIdsInput {
   collapsedIds: string[];
-  nodes: InternalGraphNode[];
-  edges: InternalGraphEdge[];
+  nodes: GraphNode[];
+  edges: GraphEdge[];
 }
 
 function getHiddenChildren({
@@ -22,18 +22,18 @@ function getHiddenChildren({
   currentHiddenNodes,
   currentHiddenEdges
 }: GetHiddenChildrenInput) {
-  const hiddenNodes: InternalGraphNode[] = [];
-  const hiddenEdges: InternalGraphEdge[] = [];
+  const hiddenNodes: GraphNode[] = [];
+  const hiddenEdges: GraphEdge[] = [];
   const curHiddenNodeIds = currentHiddenNodes.map(n => n.id);
   const curHiddenEdgeIds = currentHiddenEdges.map(e => e.id);
 
-  const outboundEdges = edges.filter(l => l.data.source === nodeId);
-  const outboundEdgeNodeIds = outboundEdges.map(l => l.data.target);
+  const outboundEdges = edges.filter(l => l.source === nodeId);
+  const outboundEdgeNodeIds = outboundEdges.map(l => l.target);
 
   hiddenEdges.push(...outboundEdges);
   for (const outboundEdgeNodeId of outboundEdgeNodeIds) {
     const incomingEdges = edges.filter(
-      l => l.data.target === outboundEdgeNodeId && l.data.source !== nodeId
+      l => l.target === outboundEdgeNodeId && l.source !== nodeId
     );
     let hideNode = false;
 
@@ -45,7 +45,7 @@ function getHiddenChildren({
       !curHiddenNodeIds.includes(outboundEdgeNodeId)
     ) {
       // If all inbound links are hidden, hide this node as well
-      const inboundNodeLinkIds = incomingEdges.map(l => l.data.id);
+      const inboundNodeLinkIds = incomingEdges.map(l => l.id);
       if (inboundNodeLinkIds.every(i => curHiddenEdgeIds.includes(i))) {
         hideNode = true;
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently a graph's initial state containing all nodes and edges is maintained within the store
Issue Number: https://linear.app/goodcodeus/issue/QAI-1/graph-collapse-refactor


## What is the new behavior?
Within useGraph, use the passed nodes and edges along with the store's collapsedNodeIds list to determine a list of visible nodes and edges. Use these to build and update the graph layout

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
It's technically a breaking change for collapsible nodes if they did not maintain their collapsed node ids. Previously the list of collapsed nodes was handled internally. Now, it is expected the user of GraphScene maintains this list

## Other information
