### PR TITLE
fix issue edge custom font not working when animated is false

### DIFF
--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -325,6 +325,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
                   edges={edges}
                   disabled={disabled}
                   animated={animated}
+                  labelFontUrl={labelFontUrl}
                   labelPlacement={edgeLabelPosition}
                   arrowPlacement={edgeArrowPosition}
                   interpolation={edgeInterpolation}

--- a/src/symbols/edges/Edge.tsx
+++ b/src/symbols/edges/Edge.tsx
@@ -33,6 +33,7 @@ export interface EdgeProps {
   color: ColorRepresentation;
   contextMenu?: (event: Partial<ContextMenuEvent>) => React.ReactNode;
   edge: InternalGraphEdge;
+  labelFontUrl?: string;
   labelPlacement?: EdgeLabelPosition;
   opacity?: number;
   theme: Theme;
@@ -43,6 +44,7 @@ export const Edge: FC<EdgeProps> = ({
   color,
   contextMenu,
   edge,
+  labelFontUrl,
   labelPlacement,
   opacity,
   theme
@@ -121,6 +123,7 @@ export const Edge: FC<EdgeProps> = ({
           <Label
             text={label}
             ellipsis={15}
+            fontUrl={labelFontUrl}
             stroke={theme.edge.label.stroke}
             color={color}
             opacity={opacity}

--- a/src/symbols/edges/Edges.tsx
+++ b/src/symbols/edges/Edges.tsx
@@ -22,6 +22,7 @@ export type EdgesProps = {
   contextMenu?: (event: Partial<ContextMenuEvent>) => React.ReactNode;
   disabled?: boolean;
   edges: Array<InternalGraphEdge>;
+  labelFontUrl?: string;
   labelPlacement?: EdgeLabelPosition;
   interpolation?: EdgeInterpolation;
   theme: Theme;
@@ -58,6 +59,7 @@ export const Edges: FC<EdgesProps> = ({
   disabled,
   edges,
   interpolation = 'linear',
+  labelFontUrl,
   labelPlacement = 'inline',
   theme,
   onClick,
@@ -243,6 +245,7 @@ export const Edges: FC<EdgesProps> = ({
           disabled={disabled}
           edge={edge}
           key={edge.id}
+          labelFontUrl={labelFontUrl}
           labelPlacement={labelPlacement}
           theme={theme}
         />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Custom font is not used on edges when animated is false

Issue Number: #120


## What is the new behavior?
Custom font is used on edges when animated is false

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
