### PR TITLE
Added heuristics for cluster boundary spacing

### DIFF
--- a/docs/assets/demo.ts
+++ b/docs/assets/demo.ts
@@ -77,7 +77,7 @@ const colors = ['#3730a3', '#c2410c', '#166534', '#075985'];
 
 export const clusterNodes: GraphNode[] =
   range(25).map(i => {
-    const idx = random(0, types.length - 1);
+    const idx = random(0, types.length);
     const type = types[idx];
 
     return {

--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -114,7 +114,11 @@ export function forceDirected({
     )
     .stop();
 
-  const centers = caluculateCenters({ nodes, clusterAttribute });
+  const centers = caluculateCenters({
+    nodes,
+    clusterAttribute,
+    strength: Math.abs(nodeStrengthAdjustment)
+  });
 
   // Initialize the simulation
   const layout = sim

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -76,11 +76,17 @@ export function caluculateCenters({
     const groups = buildClusterGroups(nodes, clusterAttribute);
     const count = groups.size;
 
+    // Heuristics to adjust spacing between clusters
+    const nodeStrengthmultiplier = nodes?.length / 100;
+    const adjustedCenterStrength =
+      (Math.max(nodeStrengthmultiplier, 2) + Math.max(count / 2, 2)) *
+      Math.abs(strength);
+
     let idx = 0;
     for (const [key] of groups) {
       const radiant = ((2 * Math.PI) / count) * idx;
-      const x = Math.cos(radiant) * strength;
-      const y = Math.sin(radiant) * strength;
+      const x = Math.cos(radiant) * adjustedCenterStrength;
+      const y = Math.sin(radiant) * adjustedCenterStrength;
       idx++;
 
       centers.set(key, {


### PR DESCRIPTION
This PR fixes the boundary overlap issue in clusters.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Boundaries overlap when there are a large number of nodes.
Example: 100 nodes in 4 clusters
<img width="756" alt="Screenshot 2023-08-08 at 12 51 17 AM" src="https://github.com/reaviz/reagraph/assets/33908100/f6c3e4e8-e489-4266-bb06-27147de3a8e2">


Issue Number: N/A


## What is the new behavior?

There is no overlap when there are large number of nodes and clusters.

Example: 100 nodes in 4 clusters
<img width="756" alt="Screenshot 2023-08-08 at 12 37 08 AM" src="https://github.com/reaviz/reagraph/assets/33908100/b23c6429-9add-4b0b-86b5-a662d2c407c7">

Example: 100 nodes in 7 clusters
<img width="756" alt="Screenshot 2023-08-08 at 12 37 22 AM" src="https://github.com/reaviz/reagraph/assets/33908100/3f60879f-4837-4a75-977a-520772d45c5a">

Example: 500 nodes in 4 clusters
<img width="749" alt="Screenshot 2023-08-08 at 12 36 44 AM" src="https://github.com/reaviz/reagraph/assets/33908100/ad9efc83-e326-4b2c-927f-e902d6a346c6">


Example: 500 nodes in 7 clusters
<img width="749" alt="Screenshot 2023-08-08 at 12 36 26 AM" src="https://github.com/reaviz/reagraph/assets/33908100/b75af410-9351-42ac-8a11-89240802c5f8">




## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
