### PR TITLE
Updated heuristics for cluster boundary spacing

### DIFF
--- a/docs/assets/demo.ts
+++ b/docs/assets/demo.ts
@@ -90,6 +90,54 @@ export const clusterNodes: GraphNode[] =
   }
 });
 
+export const singleNodeClusterNodes: GraphNode[] =
+  range(2).map(i => {
+
+    const idx = i
+    const type = i;
+
+    return {
+    id: `n-${i}`,
+    label: `${type} ${i}`,
+    fill: colors[idx],
+    data: {
+      type
+    }
+  }
+});
+
+export const imbalancedClusterNodes: GraphNode[] =
+  range(20).map(i => {
+    const idx = (i == 0) ? 2: (i % 2);
+    const type = types[idx];
+
+    return {
+    id: `n-${i}`,
+    label: `${type} ${i}`,
+    fill: colors[idx],
+    data: {
+      type
+    }
+  }
+});
+
+const manyTypes = ['IPV4', 'URL', 'Email', 'MD5', 'SHA256', 'Domain', 'IPV6', 'CRC32', 'SHA512'];
+
+export const manyClusterNodes: GraphNode[] =
+  range(500).map(i => {
+    const idx = random(0, manyTypes.length);
+    const type = manyTypes[idx];
+
+    return {
+    id: `n-${i}`,
+    label: `${type} ${i}`,
+    fill: colors[idx%colors.length],
+    data: {
+      type
+    }
+  }
+});
+
 export const clusterEdges: GraphEdge[] = range(random(5, 25)).map(i => ({
   id: `e-${i}`,
   source: `n-${i}`,

--- a/docs/demos/Cluster.story.tsx
+++ b/docs/demos/Cluster.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GraphCanvas, lightTheme } from '../../src';
-import { clusterNodes, clusterEdges, random } from '../assets/demo';
+import { clusterNodes, clusterEdges, random, singleNodeClusterNodes, imbalancedClusterNodes, manyClusterNodes } from '../assets/demo';
 
 export default {
   title: 'Demos/Cluster',
@@ -18,6 +18,18 @@ const clusterNodesWithSizes = clusterNodes.map(node => ({
 
 export const Sizes = () => (
   <GraphCanvas nodes={clusterNodesWithSizes} draggable edges={[]} clusterAttribute="type" />
+);
+
+export const SingleNodeClusters = () => (
+  <GraphCanvas nodes={singleNodeClusterNodes} draggable edges={[]} clusterAttribute="type" />
+);
+
+export const ImbalancedClusters = () => (
+  <GraphCanvas nodes={imbalancedClusterNodes} draggable edges={[]} clusterAttribute="type" />
+);
+
+export const LargeDataset = () => (
+  <GraphCanvas nodes={manyClusterNodes} draggable edges={[]} clusterAttribute="type" />
 );
 
 export const Edges = () => (

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -74,19 +74,28 @@ export function caluculateCenters({
 
   if (clusterAttribute) {
     const groups = buildClusterGroups(nodes, clusterAttribute);
-    const count = groups.size;
+    const numGroups = groups.size;
+    const numNodes = nodes?.length;
 
     // Heuristics to adjust spacing between clusters
-    const nodeStrengthMultiplier = nodes?.length / 100;
-    const adjustedCenterStrength =
-      (Math.max(nodeStrengthMultiplier, 2) + Math.max(count / 2, 2)) *
-      Math.abs(strength);
+    const [maxCap, numGroupsFactor] =
+      numGroups < 6 ? [8, 10 * numGroups] : [20, 20 * numGroups];
 
     let idx = 0;
-    for (const [key] of groups) {
-      const radiant = ((2 * Math.PI) / count) * idx;
-      const x = Math.cos(radiant) * adjustedCenterStrength;
-      const y = Math.sin(radiant) * adjustedCenterStrength;
+    for (const [key, value] of groups) {
+      const radiant = ((2 * Math.PI) / numGroups) * idx;
+      const groupSize = value.length;
+
+      // Heuristics to adjust spacing between clusters
+      const factor = (groupSize * numGroupsFactor) / numNodes;
+      const cappedFactor =
+        groupSize < 10 && numGroups < 8
+          ? numGroups / 2
+          : Math.max(2, Math.min(maxCap, factor));
+
+      const x = Math.cos(radiant) * strength * cappedFactor;
+      const y = Math.sin(radiant) * strength * cappedFactor;
+
       idx++;
 
       centers.set(key, {


### PR DESCRIPTION
This PR:-

- Updates the heuristics to handle some edge cases like below

Single Node Clusters
<img width="785" alt="Screenshot 2023-08-18 at 5 49 23 PM" src="https://github.com/reaviz/reagraph/assets/33908100/31d39e4e-6197-4747-97be-ac6050f39537">


Imbalanced Clusters
<img width="582" alt="Screenshot 2023-08-18 at 5 49 51 PM" src="https://github.com/reaviz/reagraph/assets/33908100/198d11fc-a046-42d9-8ae8-b6d446f43b2a">


Large Dataset
<img width="648" alt="Screenshot 2023-08-18 at 5 50 10 PM" src="https://github.com/reaviz/reagraph/assets/33908100/d15eb6b4-26d2-4ea9-8ebb-83c715b48da3">
