### PR TITLE
Add glOptions to GraphCanvas to extend gl configutation

### DIFF
--- a/docs/demos/Basic.story.tsx
+++ b/docs/demos/Basic.story.tsx
@@ -135,3 +135,12 @@ export const LiveUpdates = () => {
 export const NoAnimation = () => (
   <GraphCanvas animated={false} nodes={simpleNodes} edges={simpleEdges} />
 );
+
+export const ExtraGlOptions = () => (
+  <GraphCanvas
+    animated={false}
+    nodes={simpleNodes}
+    edges={simpleEdges}
+    glOptions={{preserveDrawingBuffer: true}}
+  />
+);

--- a/src/GraphCanvas.tsx
+++ b/src/GraphCanvas.tsx
@@ -5,7 +5,8 @@ import React, {
   Ref,
   Suspense,
   useImperativeHandle,
-  useRef
+  useRef,
+  useMemo
 } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { GraphScene, GraphSceneProps, GraphSceneRef } from './GraphScene';
@@ -56,6 +57,11 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
    * Children to render in the canvas. Useful for things like lights.
    */
   children?: ReactNode;
+
+  /**
+   * Ability to extend Cavas gl options. For example { preserveDrawingBuffer: true }
+   */
+  glOptions?: Object;
 }
 
 export type GraphCanvasRef = Omit<GraphSceneRef, 'graph'> &
@@ -99,6 +105,7 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
         lassoType,
         onLasso,
         onLassoEnd,
+        glOptions,
         ...rest
       },
       ref: Ref<GraphCanvasRef>
@@ -126,6 +133,9 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
       // It's pretty hard to get good animation performance with large n of edges/nodes
       const finalAnimated =
         edges.length + nodes.length > 400 ? false : animated;
+      const gl = useMemo(() => {
+        return { ...glOptions, ...GL_DEFAULTS };
+      }, [glOptions]);
 
       // NOTE: The legacy/linear/flat flags are for color issues
       // Reference: https://github.com/protectwise/troika/discussions/213#discussioncomment-3086666
@@ -135,7 +145,7 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
             legacy
             linear
             flat
-            gl={GL_DEFAULTS}
+            gl={gl}
             camera={CAMERA_DEFAULTS}
             onPointerMissed={onCanvasClick}
           >
@@ -198,5 +208,6 @@ GraphCanvas.defaultProps = {
   defaultNodeSize: 7,
   minNodeSize: 5,
   maxNodeSize: 15,
-  lassoType: 'none'
+  lassoType: 'none',
+  glOptions: {}
 };


### PR DESCRIPTION
After some internet search, found that to make ability to save/download Canvas as a picture extra configuration should be passed to `gl` attribute as `preserveDrawingBuffer: true`. To avoid hardcoded value, decided to make it as configurable parameter on user level.

```js
// If canvas is created like this:
<GraphCanvas glOptions={{ preserveDrawingBuffer: true }}/>


// the following pseudo-code should work
const url = getControls()._domElement?.toDataURL();
const fakeDownloader = document.createElement('a');
fakeDownloader.href = url;
fakeDownloader.download = 'canvas';
fakeDownloader.click();
fakeDownloader.remove();

```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
