### PR TITLE
Add doubleClick to <Node/>

### DIFF
--- a/docs/demos/Basic.story.tsx
+++ b/docs/demos/Basic.story.tsx
@@ -135,3 +135,29 @@ export const LiveUpdates = () => {
 export const NoAnimation = () => (
   <GraphCanvas animated={false} nodes={simpleNodes} edges={simpleEdges} />
 );
+
+export const NodeDoubleClick = () => (
+  <GraphCanvas
+    nodes={[{
+      id: '1',
+      label: 'Node 1'
+    },
+    {
+      id: '2',
+      label: 'Node 2'
+    }]}
+    edges={[{
+      source: '1',
+      target: '2',
+      id: '1-2',
+      label: '1-2'
+    },
+    {
+      source: '2',
+      target: '1',
+      id: '2-1',
+      label: '2-1'
+    }]}
+    onNodeDoubleClick={(node) => alert(node.label)}
+  />
+);

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -165,6 +165,11 @@ export interface GraphSceneProps {
   onNodeClick?: (node: InternalGraphNode, props?: CollapseProps) => void;
 
   /**
+   * When a node was double clicked.
+   */
+  onNodeDoubleClick?: (node: InternalGraphNode) => void;
+
+  /**
    * When a node context menu happened.
    */
   onNodeContextMenu?: (
@@ -240,6 +245,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
     (
       {
         onNodeClick,
+        onNodeDoubleClick,
         onNodeContextMenu,
         onEdgeContextMenu,
         onEdgeClick,
@@ -303,6 +309,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
                   contextMenu={contextMenu}
                   renderNode={renderNode}
                   onClick={onNodeClick}
+                  onDoubleClick={onNodeDoubleClick}
                   onContextMenu={onNodeContextMenu}
                   onPointerOver={onNodePointerOver}
                   onPointerOut={onNodePointerOut}

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -84,6 +84,11 @@ export interface NodeProps {
   onClick?: (node: InternalGraphNode, props?: CollapseProps) => void;
 
   /**
+   * The function to call when the node is double clicked.
+   */
+  onDoubleClick?: (node: InternalGraphNode) => void;
+
+  /**
    * The function to call when the node is right clicked.
    */
   onContextMenu?: (
@@ -105,6 +110,7 @@ export const Node: FC<NodeProps> = ({
   labelFontUrl,
   contextMenu,
   onClick,
+  onDoubleClick,
   onPointerOver,
   onDragged,
   onPointerOut,
@@ -230,6 +236,11 @@ export const Node: FC<NodeProps> = ({
             canCollapse,
             isCollapsed
           });
+        }
+      }}
+      onDoubleClick={() => {
+        if (!disabled && !isDragging) {
+          onDoubleClick?.(node);
         }
       }}
       onContextMenu={() => {


### PR DESCRIPTION
Adding ability to handle double click event on `<Node/>`.
Use case I was trying to cover, if for example we have Team object as `<Node/>` and when user double clicks on it, I want to get more nodes (as hierarchy inside the team) and re-render the graph.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
