### PR TITLE
change labelFontUrl to fontUrl for cluster

### DIFF
--- a/src/symbols/Cluster.tsx
+++ b/src/symbols/Cluster.tsx
@@ -179,7 +179,7 @@ export const Cluster: FC<ClusterProps> = ({
               <Label
                 text={label}
                 opacity={opacity}
-                labelFontUrl={labelFontUrl}
+                fontUrl={labelFontUrl}
                 stroke={theme.cluster.label.stroke}
                 active={false}
                 color={theme.cluster.label.color}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
*Literally this is first time I contribute in github and pardon my english*
I am modifying a line of code where if labelFontUrl is signed, label on cluster didn't work just like node label, it still show squareboxes
![image](https://github.com/reaviz/reagraph/assets/70207170/ef813ab8-cda3-46e2-aba6-b2939a3ee1a0)
Literally just some typo in Cluster.js `<Label>` where should be fontUrl not labelFontUrl

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
