### PR TITLE
add extended Theme support for Edge and Node

### DIFF
--- a/docs/DataShapes.mdx
+++ b/docs/DataShapes.mdx
@@ -10,6 +10,7 @@ The graph is made up of 2 basic data shape objects you can pass to the graph.
 - `GraphEdge` - The link between Nodes
 
 ## GraphElementBaseAttributes
+
 ```ts
 export interface GraphElementBaseAttributes<T = any> {
   /**
@@ -40,6 +41,7 @@ export interface GraphElementBaseAttributes<T = any> {
 ```
 
 ## GraphNode
+
 ```ts
 export interface GraphNode extends GraphElementBaseAttributes {
   /**
@@ -51,10 +53,32 @@ export interface GraphNode extends GraphElementBaseAttributes {
    * Fill color for the node.
    */
   fill?: string;
+  theme?: {
+    fill?: string;
+    activeFill?: ColorRepresentation;
+    opacity?: number;
+    selectedOpacity?: number;
+    inactiveOpacity?: number;
+    label?: {
+      color?: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor?: ColorRepresentation;
+    };
+    subLabel?: {
+      color?: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor?: ColorRepresentation;
+    };
+    ring?: {
+      fill?: ColorRepresentation;
+      activeFill?: ColorRepresentation;
+    };
+  };
 }
 ```
 
 ## GraphEdge
+
 ```ts
 export interface GraphEdge extends GraphElementBaseAttributes {
   /**

--- a/docs/assets/demo.ts
+++ b/docs/assets/demo.ts
@@ -5,14 +5,13 @@ import computerSvg from './computer.svg';
 
 export const random = (floor, ceil) => Math.floor(Math.random() * ceil) + floor;
 
-export const simpleNodes: GraphNode[] =
-  range(5).map(i => ({
-    id: `n-${i}`,
-    label: `Node ${i}`,
-    data: {
-      priority: random(0, 10)
-    }
-  }));
+export const simpleNodes: GraphNode[] = range(5).map(i => ({
+  id: `n-${i}`,
+  label: `Node ${i}`,
+  data: {
+    priority: random(0, 10)
+  }
+}));
 
 export const parentNodes: GraphNode[] = [
   ...range(5).map(i => {
@@ -70,72 +69,77 @@ export const parentNodes: GraphNode[] = [
       priority: random(0, 10)
     }
   }
-]
+];
 
 const types = ['IP', 'URL', 'Email', 'MD5'];
 const colors = ['#3730a3', '#c2410c', '#166534', '#075985'];
 
-export const clusterNodes: GraphNode[] =
-  range(25).map(i => {
-    const idx = random(0, types.length);
-    const type = types[idx];
+export const clusterNodes: GraphNode[] = range(25).map(i => {
+  const idx = random(0, types.length);
+  const type = types[idx];
 
-    return {
+  return {
     id: `n-${i}`,
     label: `${type} ${i}`,
     fill: colors[idx],
     data: {
       type
     }
-  }
+  };
 });
 
-export const singleNodeClusterNodes: GraphNode[] =
-  range(2).map(i => {
+export const singleNodeClusterNodes: GraphNode[] = range(2).map(i => {
+  const idx = i;
+  const type = i;
 
-    const idx = i
-    const type = i;
-
-    return {
+  return {
     id: `n-${i}`,
     label: `${type} ${i}`,
     fill: colors[idx],
     data: {
       type
     }
-  }
+  };
 });
 
-export const imbalancedClusterNodes: GraphNode[] =
-  range(20).map(i => {
-    const idx = (i == 0) ? 2: (i % 2);
-    const type = types[idx];
+export const imbalancedClusterNodes: GraphNode[] = range(20).map(i => {
+  const idx = i == 0 ? 2 : i % 2;
+  const type = types[idx];
 
-    return {
+  return {
     id: `n-${i}`,
     label: `${type} ${i}`,
     fill: colors[idx],
     data: {
       type
     }
-  }
+  };
 });
 
-const manyTypes = ['IPV4', 'URL', 'Email', 'MD5', 'SHA256', 'Domain', 'IPV6', 'CRC32', 'SHA512'];
+const manyTypes = [
+  'IPV4',
+  'URL',
+  'Email',
+  'MD5',
+  'SHA256',
+  'Domain',
+  'IPV6',
+  'CRC32',
+  'SHA512'
+];
 
-export const manyClusterNodes: GraphNode[] =
-  range(500).map(i => {
-    const idx = random(0, manyTypes.length);
-    const type = manyTypes[idx];
+export const manyClusterNodes: GraphNode[] = range(500).map(i => {
+  const idx = random(0, manyTypes.length);
+  const type = manyTypes[idx];
 
-    return {
+  return {
     id: `n-${i}`,
     label: `${type} ${i}`,
-    fill: colors[idx%colors.length],
+    fill: colors[idx % colors.length],
     data: {
       type
     }
-  }
+  };
 });
 
 export const clusterEdges: GraphEdge[] = range(random(5, 25)).map(i => ({
@@ -145,32 +149,33 @@ export const clusterEdges: GraphEdge[] = range(random(5, 25)).map(i => ({
   label: '0-1'
 }));
 
-export const simpleNodesColors: GraphNode[] =
-  range(5).map(i => ({
-    id: `n-${i}`,
-    label: `Node ${i}`,
+export const simpleNodesColors: GraphNode[] = range(5).map(i => ({
+  id: `n-${i}`,
+  label: `Node ${i}`,
+  size: i % 2 === 0 ? 50 : 25,
+  theme: {
     fill: `hsl(${random(0, 360)}, 100%, 50%)`,
-  }));
+    activeFill: `hsl(${random(0, 360)}, 100%, 50%)`
+  }
+}));
 
-export const iconNodes: GraphNode[] =
-  range(5).map(i => ({
-    id: `n-${i}`,
-    label: `Node ${i}`,
-    size: i % 2 === 0 ? 50 : 25,
-    icon: i % 2 === 0 ? computerSvg : demonSvg,
-    data: {
-      priority: random(0, 10)
-    }
-  }));
+export const iconNodes: GraphNode[] = range(5).map(i => ({
+  id: `n-${i}`,
+  label: `Node ${i}`,
+  size: i % 2 === 0 ? 50 : 25,
+  icon: i % 2 === 0 ? computerSvg : demonSvg,
+  data: {
+    priority: random(0, 10)
+  }
+}));
 
-export const manyNodes: GraphNode[] =
-  range(100).map(i => ({
-    id: `n-${i}`,
-    label: `Node ${i}`,
-    data: {
-      priority: Math.floor(Math.random() * 10) + 1
-    }
-  }));
+export const manyNodes: GraphNode[] = range(100).map(i => ({
+  id: `n-${i}`,
+  label: `Node ${i}`,
+  data: {
+    priority: Math.floor(Math.random() * 10) + 1
+  }
+}));
 
 export const simpleEdges: GraphEdge[] = [
   {
@@ -198,6 +203,18 @@ export const simpleEdges: GraphEdge[] = [
     label: 'Edge 0-4'
   }
 ];
+
+export const simpleNodesEdges: GraphNode[] = simpleEdges.map((edge, index) => ({
+  ...edge,
+  size: index % 2 ? 2 : 6,
+  theme: {
+    fill: `hsl(${random(0, 360)}, 100%, 50%)`,
+    activeFill: `hsl(${random(0, 360)}, 100%, 50%)`,
+    arrow: {
+      fill: `hsl(${random(0, 360)}, 100%, 50%)`
+    }
+  }
+}));
 
 export const parentEdges: GraphEdge[] = [
   ...simpleEdges,
@@ -231,7 +248,7 @@ export const parentEdges: GraphEdge[] = [
     target: 'n-2-n-0-n-0',
     label: 'Edge 3-2-0'
   }
-]
+];
 
 export const treeEdges: GraphEdge[] = [
   {
@@ -260,11 +277,10 @@ export const treeEdges: GraphEdge[] = [
   }
 ];
 
-export const complexNodes: GraphNode[] =
-  range(25).map(i => ({
-    id: `${i}`,
-    label: `Node ${i}`
-  }));
+export const complexNodes: GraphNode[] = range(25).map(i => ({
+  id: `${i}`,
+  label: `Node ${i}`
+}));
 
 export const complexEdges = [
   { id: '0->2', source: '0', target: '2', label: 'Edge 0-2' },
@@ -307,5 +323,5 @@ export const complexEdges = [
   { id: '12->15', source: '12', target: '15', label: 'Edge 12-15' },
   { id: '13->16', source: '13', target: '16', label: 'Edge 13-16' },
   { id: '14->17', source: '14', target: '17', label: 'Edge 14-17' },
-  { id: '15->18', source: '15', target: '18', label: 'Edge 15-18' },
+  { id: '15->18', source: '15', target: '18', label: 'Edge 15-18' }
 ];

--- a/docs/demos/Nodes.story.tsx
+++ b/docs/demos/Nodes.story.tsx
@@ -1,9 +1,16 @@
 import React, { useRef, useState } from 'react';
-import { GraphCanvas, Svg, LayoutTypes, SphereWithIcon, SphereWithSvg } from '../../src';
+import {
+  GraphCanvas,
+  Svg,
+  LayoutTypes,
+  SphereWithIcon,
+  SphereWithSvg
+} from '../../src';
 import {
   iconNodes,
   manyNodes,
   simpleEdges,
+  simpleNodesEdges,
   simpleNodes,
   simpleNodesColors
 } from '../assets/demo';
@@ -16,10 +23,7 @@ export default {
 export const NoEdges = () => <GraphCanvas nodes={manyNodes} edges={[]} />;
 
 export const Icons = () => (
-  <GraphCanvas
-    nodes={iconNodes}
-    edges={simpleEdges}
-  />
+  <GraphCanvas nodes={iconNodes} edges={simpleEdges} />
 );
 
 export const DragOverrides = () => {
@@ -33,8 +37,8 @@ export const DragOverrides = () => {
         nodes={nodes}
         edges={simpleEdges}
         layoutOverrides={{
-          getNodePosition: (id) => {
-            console.log('custom position', nodeRef.current.get(id))
+          getNodePosition: id => {
+            console.log('custom position', nodeRef.current.get(id));
             return nodeRef.current.get(id)?.position;
           }
         }}
@@ -48,7 +52,7 @@ export const DragOverrides = () => {
           type="button"
           onClick={() => {
             const next = nodes.length + 2;
-            setNodes([...nodes, { id: `${next}`, label: `Node ${next}` }])
+            setNodes([...nodes, { id: `${next}`, label: `Node ${next}` }]);
           }}
         >
           Reset Graph
@@ -84,12 +88,8 @@ export const SphereWithIconNode = () => (
     nodes={iconNodes}
     edges={simpleEdges}
     cameraMode="rotate"
-    renderNode={({  node, ...rest }) => (
-      <SphereWithIcon
-        {...rest}
-        node={node}
-        image={node.icon || ''}
-      />
+    renderNode={({ node, ...rest }) => (
+      <SphereWithIcon {...rest} node={node} image={node.icon || ''} />
     )}
   />
 );
@@ -99,12 +99,8 @@ export const SphereSvgIconNode = () => (
     nodes={iconNodes}
     edges={simpleEdges}
     cameraMode="rotate"
-    renderNode={({  node, ...rest }) => (
-      <SphereWithSvg
-        {...rest}
-        node={node}
-        image={node.icon || ''}
-      />
+    renderNode={({ node, ...rest }) => (
+      <SphereWithSvg {...rest} node={node} image={node.icon || ''} />
     )}
   />
 );
@@ -114,18 +110,14 @@ export const SvgIconNode = () => (
     nodes={iconNodes}
     edges={simpleEdges}
     cameraMode="rotate"
-    renderNode={({  node, ...rest }) => (
-      <Svg
-        {...rest}
-        node={node}
-        image={node.icon || ''}
-      />
+    renderNode={({ node, ...rest }) => (
+      <Svg {...rest} node={node} image={node.icon || ''} />
     )}
   />
 );
 
 export const Colors = () => (
-  <GraphCanvas nodes={simpleNodesColors} edges={simpleEdges} />
+  <GraphCanvas nodes={simpleNodesColors} edges={simpleNodesEdges} />
 );
 
 export const Draggable = () => {

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -12,7 +12,6 @@ import {
   getVector
 } from '../utils';
 import { Line } from './Line';
-import { Theme } from '../themes';
 import { useStore } from '../store';
 import { ContextMenuEvent, InternalGraphEdge } from '../types';
 import { Html, useCursor } from '@react-three/drei';
@@ -163,9 +162,9 @@ export const Edge: FC<EdgeProps> = ({
 
   const selectionOpacity = hasSelections
     ? isSelected || isActive
-      ? theme.edge.selectedOpacity
-      : theme.edge.inactiveOpacity
-    : theme.edge.opacity;
+      ? edge.theme?.selectedOpacity ?? theme.edge.selectedOpacity
+      : edge.theme?.inactiveOpacity ?? theme.edge.inactiveOpacity
+    : edge.theme?.opacity ?? theme.edge.opacity;
 
   const [{ labelPosition }] = useSpring(
     () => ({
@@ -224,8 +223,8 @@ export const Edge: FC<EdgeProps> = ({
         animated={animated}
         color={
           isSelected || active || isActive
-            ? theme.edge.activeFill
-            : theme.edge.fill
+            ? edge.theme?.activeFill ?? theme.edge.activeFill
+            : edge.theme?.fill ?? theme.edge.fill
         }
         curve={curve}
         curved={curved}
@@ -251,8 +250,8 @@ export const Edge: FC<EdgeProps> = ({
           animated={animated}
           color={
             isSelected || active || isActive
-              ? theme.arrow.activeFill
-              : theme.arrow.fill
+              ? edge.theme?.arrow?.activeFill ?? theme.arrow.activeFill
+              : edge.theme?.arrow?.fill ?? theme.arrow.fill
           }
           length={arrowLength}
           opacity={selectionOpacity}
@@ -274,11 +273,11 @@ export const Edge: FC<EdgeProps> = ({
             text={label}
             ellipsis={15}
             fontUrl={labelFontUrl}
-            stroke={theme.edge.label.stroke}
+            stroke={edge.theme?.label?.stroke || theme.edge.label.stroke}
             color={
               isSelected || active || isActive
-                ? theme.edge.label.activeColor
-                : theme.edge.label.color
+                ? edge.theme?.label?.activeColor || theme.edge.label.activeColor
+                : edge.theme?.label?.color || theme.edge.label.color
             }
             opacity={selectionOpacity}
             fontSize={LABEL_FONT_SIZE}

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -11,7 +11,6 @@ import { animationConfig } from '../utils';
 import { useSpring, a } from '@react-spring/three';
 import { Sphere } from './nodes/Sphere';
 import { Label } from './Label';
-import { Theme } from '../themes';
 import { Ring } from './Ring';
 import {
   NodeContextMenuProps,
@@ -146,9 +145,9 @@ export const Node: FC<NodeProps> = ({
 
   const selectionOpacity = hasSelections
     ? isSelected || active || isActive
-      ? theme.node.selectedOpacity
-      : theme.node.inactiveOpacity
-    : theme.node.opacity;
+      ? node?.theme?.selectedOpacity ?? theme.node.selectedOpacity
+      : node?.theme?.inactiveOpacity ?? theme.node.inactiveOpacity
+    : node?.theme?.opacity ?? theme.node.opacity;
 
   const canCollapse = useMemo(() => {
     // If the node has outgoing edges, it can collapse via context menu
@@ -214,10 +213,15 @@ export const Node: FC<NodeProps> = ({
   );
   useCursor(isDragging, 'grabbing');
 
+  if (node?.fill) {
+    console.warn(
+      'DeprecationWarning: Using node.fill is deprecated. Please use node.theme.fill instead.'
+    );
+  }
   const combinedActiveState = isSelected || active || isDragging || isActive;
   const color = combinedActiveState
-    ? theme.node.activeFill
-    : node.fill || theme.node.fill;
+    ? node?.theme?.activeFill ?? theme.node.activeFill
+    : node?.fill ?? (node?.theme?.fill || theme.node.fill);
 
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled: disabled || isDragging,
@@ -303,7 +307,11 @@ export const Node: FC<NodeProps> = ({
         opacity={isSelected ? 0.5 : 0}
         size={nodeSize}
         animated={animated}
-        color={isSelected || active ? theme.ring.activeFill : theme.ring.fill}
+        color={
+          isSelected || active
+            ? node?.theme?.ring?.activeFill ?? theme.ring.activeFill
+            : node?.theme?.ring?.fill ?? theme.ring.fill
+        }
       />
       {menuVisible && contextMenu && (
         <Html prepend={true} center={true}>
@@ -323,12 +331,13 @@ export const Node: FC<NodeProps> = ({
               text={label}
               fontUrl={labelFontUrl}
               opacity={selectionOpacity}
-              stroke={theme.node.label.stroke}
+              stroke={node?.theme?.label?.stroke ?? theme.node.label.stroke}
               active={isSelected || active || isDragging || isActive}
               color={
                 isSelected || active || isDragging || isActive
-                  ? theme.node.label.activeColor
-                  : theme.node.label.color
+                  ? node?.theme?.label?.activeColor ??
+                    theme.node.label.activeColor
+                  : node?.theme?.label?.color ?? theme.node.label.color
               }
             />
           </a.group>
@@ -339,12 +348,15 @@ export const Node: FC<NodeProps> = ({
                 fontUrl={labelFontUrl}
                 fontSize={5}
                 opacity={selectionOpacity}
-                stroke={theme.node.subLabel?.stroke}
+                stroke={
+                  node?.theme?.subLabel?.stroke ?? theme.node.subLabel?.stroke
+                }
                 active={isSelected || active || isDragging || isActive}
                 color={
                   isSelected || active || isDragging || isActive
-                    ? theme.node.subLabel?.activeColor
-                    : theme.node.subLabel?.color
+                    ? node?.theme?.subLabel?.activeColor ??
+                      theme.node.subLabel?.activeColor
+                    : node?.theme?.subLabel?.color ?? theme.node.subLabel?.color
                 }
               />
             </a.group>

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,8 +46,30 @@ export interface GraphNode extends GraphElementBaseAttributes {
 
   /**
    * Fill color for the node.
+   * @deprecated use theme.fill
    */
   fill?: string;
+  theme?: {
+    fill?: string;
+    activeFill?: ColorRepresentation;
+    opacity?: number;
+    selectedOpacity?: number;
+    inactiveOpacity?: number;
+    label?: {
+      color?: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor?: ColorRepresentation;
+    };
+    subLabel?: {
+      color?: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor?: ColorRepresentation;
+    };
+    ring?: {
+      fill?: ColorRepresentation;
+      activeFill?: ColorRepresentation;
+    };
+  };
 }
 
 export interface GraphEdge extends GraphElementBaseAttributes {
@@ -60,6 +82,23 @@ export interface GraphEdge extends GraphElementBaseAttributes {
    * Target ID of the node.
    */
   target: string;
+
+  theme?: {
+    fill?: ColorRepresentation;
+    activeFill?: ColorRepresentation;
+    opacity?: number;
+    selectedOpacity?: number;
+    inactiveOpacity?: number;
+    label?: {
+      color?: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor?: ColorRepresentation;
+    };
+    arrow?: {
+      fill?: ColorRepresentation;
+      activeFill?: ColorRepresentation;
+    };
+  };
 }
 
 export interface Graph {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [?] Tests for the changes have been added (for bug fixes / features) 
  - did not find any tests. updated Storybook
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
add extended support for Node and Edge specific Theme support
- added theme Property to `GraphNode`
- added theme Property to `GraphEdge`
- deprectated `fill` Property in `GraphNode` (Hint to node.theme.fill added)
- updated Storybook to showcase extended Color Support

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
only Node specific fill Color is supported

Issue Number: N/A


## What is the new behavior?
Different colors for fill, activeFill,... can be defined for each node and edge

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
I would deprecated previous fill Property. If this is not intended, deprecation hints can be removed


