### PR TITLE
Fix label position on curved edges

### DIFF
--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -17,7 +17,7 @@ import { useStore } from '../store';
 import { ContextMenuEvent, InternalGraphEdge } from '../types';
 import { Html, useCursor } from '@react-three/drei';
 import { useHoverIntent } from '../utils/useHoverIntent';
-import { Euler } from 'three';
+import { Euler, Vector3 } from 'three';
 
 export const LABEL_FONT_SIZE = 6;
 
@@ -147,15 +147,21 @@ export const Edge: FC<EdgeProps> = ({
     return [curve, arrowPosition, arrowRotation];
   }, [curved, from, to, arrowPlacement, arrowLength]);
 
-  const midPoint = useMemo(
-    () =>
-      getMidPoint(
-        from.position,
-        to.position,
-        getLabelOffsetByType(labelOffset, labelPlacement)
-      ),
-    [from.position, to.position, labelOffset, labelPlacement]
-  );
+  const midPoint = useMemo(() => {
+    let newMidPoint = getMidPoint(
+      from.position,
+      to.position,
+      getLabelOffsetByType(labelOffset, labelPlacement)
+    );
+
+    if (curved) {
+      // Offset the label to the mid point of the curve
+      const offset = new Vector3().subVectors(newMidPoint, curve.getPoint(0.5));
+      newMidPoint = newMidPoint.sub(offset);
+    }
+
+    return newMidPoint;
+  }, [from.position, to.position, labelOffset, labelPlacement, curved, curve]);
 
   const isSelected = useStore(state => state.selections?.includes(id));
   const hasSelections = useStore(state => state.selections?.length);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Edge labels aren't positioned near the edge when using curved edges


## What is the new behavior?
Edge labels are positioned on the edge for curved edges

Note: I noticed that the `above` and `below` `edgeLabelPosition` prop has no effect on this new label placement on curved edges. They always position inline. `natural` still works tho. I couldn't figure out why 🤔 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**BEFORE**

![Screenshot 2023-12-07 at 10 35 40 AM](https://github.com/reaviz/reagraph/assets/40581813/5e022774-d540-48c0-84fd-651bfb76387d)
![Screenshot 2023-12-07 at 10 35 20 AM](https://github.com/reaviz/reagraph/assets/40581813/40c8fca0-e9e9-41f4-b67f-b555fe001701)

**AFTER**

![Screenshot 2023-12-07 at 10 52 51 AM](https://github.com/reaviz/reagraph/assets/40581813/ad959ed1-4533-48c5-ad79-fd5578d66011)

![Screenshot 2023-12-07 at 10 52 39 AM](https://github.com/reaviz/reagraph/assets/40581813/80ce8a14-15ca-46de-8b29-47b57cbba706)
