### PR TITLE
Add overrides for node size to Hierarchical 2D

### DIFF
--- a/docs/Layouts.mdx
+++ b/docs/Layouts.mdx
@@ -231,9 +231,17 @@ This layout supports the following overrides:
 ```ts
 export interface HierarchicalLayoutInputs extends LayoutFactoryProps {
   /**
-   * Direction of the layout.
+   * Direction of the layout. Default 'td'.
    */
   mode?: 'td' | 'lr';
+  /**
+  * Factor of distance between nodes. Default 1.
+  */
+  nodeSeparation?: number;
+  /**
+  * Size of each node. Default [50,50]
+  */
+  nodeSize?: [number, number];
 }
 ```
 

--- a/src/layout/hierarchical.ts
+++ b/src/layout/hierarchical.ts
@@ -6,9 +6,17 @@ import { buildNodeEdges } from './layoutUtils';
 
 export interface HierarchicalLayoutInputs extends LayoutFactoryProps {
   /**
-   * Direction of the layout.
+   * Direction of the layout. Default 'td'.
    */
   mode?: 'td' | 'lr';
+  /**
+   * Factor of distance between nodes. Default 1.
+   */
+  nodeSeparation?: number;
+  /**
+   * Size of each node. Default [50,50]
+   */
+  nodeSize?: [number, number];
 }
 
 const DIRECTION_MAP = {
@@ -28,6 +36,8 @@ export function hierarchical({
   graph,
   drags,
   mode = 'td',
+  nodeSeparation = 1,
+  nodeSize = [50, 50],
   getNodePosition
 }: HierarchicalLayoutInputs): LayoutStrategy {
   const { nodes, edges } = buildNodeEdges(graph);
@@ -40,8 +50,8 @@ export function hierarchical({
     .parentId(d => d.ins?.[0]?.data?.id)(rootNodes);
 
   const treeRoot = tree()
-    .separation(() => 1)
-    .nodeSize([50, 50])(hierarchy(root));
+    .separation(() => nodeSeparation)
+    .nodeSize(nodeSize)(hierarchy(root));
 
   const treeNodes = treeRoot.descendants();
   const path = DIRECTION_MAP[mode];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
In some cases, when using the Hierarchical 2D layout, nodes can overlap if the text is large and there is no easy way for the user to space out the nodes.

Issue Number: N/A


## What is the new behavior?
The user can space out the nodes by modifying the layout override nodeSeparation or increase the static size of each node using the nodeSize layout override of HierarchicalLayoutInputs. The new layout overrides are optionals and the default values are set to the existing hardcoded values.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Examples :
With default values (same as before this change) :
<img width="1238" alt="image" src="https://github.com/reaviz/reagraph/assets/2964303/34dc1143-8fb4-43dc-a36a-de0e7968e5b4">

With a node separation of 1.5
<img width="1250" alt="image" src="https://github.com/reaviz/reagraph/assets/2964303/929034ba-062e-45c9-9621-a944e296c216">

With a node size of [100,50]
<img width="1259" alt="image" src="https://github.com/reaviz/reagraph/assets/2964303/01596ca0-b17c-4a83-9856-5ab7b93e0249">
