### PR TITLE
Make partial clusters if clusterAttribute it not defined

### DIFF
--- a/docs/assets/demo.ts
+++ b/docs/assets/demo.ts
@@ -85,7 +85,8 @@ export const clusterNodes: GraphNode[] =
     label: `${type} ${i}`,
     fill: colors[idx],
     data: {
-      type
+      type,
+      segment: i %2 === 0 ? 'A' : undefined
     }
   }
 });

--- a/docs/demos/Cluster.story.tsx
+++ b/docs/demos/Cluster.story.tsx
@@ -107,3 +107,8 @@ export const ThreeDimensions = () => (
     <directionalLight position={[0, 5, -4]} intensity={1} />
   </GraphCanvas>
 );
+
+
+export const Partial = () => (
+  <GraphCanvas nodes={clusterNodes} draggable edges={[]} clusterAttribute="segment" />
+);

--- a/src/layout/forceInABox.ts
+++ b/src/layout/forceInABox.ts
@@ -272,14 +272,6 @@ export function forceInABox() {
       return;
     }
 
-    if (nodes && nodes.length > 0) {
-      if (groupBy(nodes[0]) === undefined) {
-        throw Error(
-          'Couldnt find the grouping attribute for the nodes. Make sure to set it up with forceInABox.groupBy("clusterAttr") before calling .links()'
-        );
-      }
-    }
-
     checkLinksAsObjects();
 
     net = getGroupsGraph();

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -14,7 +14,9 @@ export function buildClusterGroups(
 
   return nodes.reduce((entryMap, e) => {
     const val = e.data[clusterAttribute];
-    entryMap.set(val, [...(entryMap.get(val) || []), e]);
+    if (val) {
+      entryMap.set(val, [...(entryMap.get(val) || []), e]);
+    }
     return entryMap;
   }, new Map());
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/reaviz/reagraph/issues/160


## What is the new behavior?

Now we can make partial clusters even if clusterAttribute is not defined in some of the nodes. 

![Screenshot 2023-12-28 at 11 01 21](https://github.com/reaviz/reagraph/assets/12369649/98dac530-48f3-4001-8540-847cb06b2b13)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
