### PR TITLE
Fix cluster overlap

### DIFF
--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -5,8 +5,7 @@ import {
   forceManyBody as d3ForceManyBody,
   forceX as d3ForceX,
   forceY as d3ForceY,
-  forceZ as d3ForceZ,
-  forceRadial as d3ForceRadial
+  forceZ as d3ForceZ
 } from 'd3-force-3d';
 import { forceRadial, DagMode } from './forceUtils';
 import { LayoutFactoryProps, LayoutStrategy } from './types';

--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -5,7 +5,8 @@ import {
   forceManyBody as d3ForceManyBody,
   forceX as d3ForceX,
   forceY as d3ForceY,
-  forceZ as d3ForceZ
+  forceZ as d3ForceZ,
+  forceRadial as d3ForceRadial
 } from 'd3-force-3d';
 import { forceRadial, DagMode } from './forceUtils';
 import { LayoutFactoryProps, LayoutStrategy } from './types';
@@ -131,6 +132,13 @@ export function forceDirected({
 
   let groupingForce;
 
+  // Dynamically adjust cluster force charge based on the number of nodes
+  let forceChargeAdjustment = forceCharge;
+  if (nodes?.length) {
+    const adjustmentFactor = Math.ceil(nodes.length / 200);
+    forceChargeAdjustment = forceCharge * adjustmentFactor;
+  }
+
   if (clusterAttribute) {
     groupingForce = forceInABox()
       // Strength to foci
@@ -152,7 +160,7 @@ export function forceDirected({
       // linkStrength between meta-nodes of the template (Force template only)
       .forceLinkStrength(forceLinkStrength)
       // Charge between the meta-nodes (Force template only)
-      .forceCharge(forceCharge)
+      .forceCharge(forceChargeAdjustment)
       // Used to compute the template force nodes size (Force template only)
       .forceNodeSize(d => d.radius);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Improvement
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Clusters start to overlap alot on larger datasets


## What is the new behavior?
Clusters overlap less on larger datasets

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This isn't a perfect fix. Some clusters are kinda far apart and there's still some overlap, but it's better than before

Before & after:
250 nodes
![Screenshot 2024-02-21 at 12 14 59 PM](https://github.com/reaviz/reagraph/assets/40581813/953d1c51-1d9f-441c-826c-cfb4eb8db702)
![Screenshot 2024-02-21 at 12 13 42 PM](https://github.com/reaviz/reagraph/assets/40581813/41ff0b9b-f507-4dda-9dce-a049f293e56b)

500 nodes
![Screenshot 2024-02-21 at 12 15 08 PM](https://github.com/reaviz/reagraph/assets/40581813/8d611ec7-3ff1-4441-bf82-d1a1af9960f4)
![Screenshot 2024-02-21 at 12 13 57 PM](https://github.com/reaviz/reagraph/assets/40581813/6fd5ca27-8a99-44f7-9b63-bb105426e518)

1000 nodes
![Screenshot 2024-02-21 at 12 15 18 PM](https://github.com/reaviz/reagraph/assets/40581813/fa580c3e-e4c7-41a3-87da-1343109777da)
![Screenshot 2024-02-21 at 12 14 10 PM](https://github.com/reaviz/reagraph/assets/40581813/9f6b75f3-9482-42f0-ba26-892f4abaf999)
