### PR TITLE
Adjust force directed 2d graph spacing

### DIFF
--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -113,12 +113,14 @@ export function forceDirected({
   const nodeStrengthAdjustment =
     is2d && edges.length > 25 ? nodeStrength * 2 : nodeStrength;
 
-  let forceX = d3ForceX(1200 / 2).strength(0.05);
-  let forceY = d3ForceY(1200 / 2).strength(0.05);
-
+  let forceX;
+  let forceY;
   if (forceLayout === 'forceDirected2d') {
     forceX = d3ForceX();
     forceY = d3ForceY();
+  } else {
+    forceX = d3ForceX(1200 / 2).strength(0.05);
+    forceY = d3ForceY(1200 / 2).strength(0.05);
   }
 
   // Create the simulation

--- a/src/layout/layoutProvider.ts
+++ b/src/layout/layoutProvider.ts
@@ -12,7 +12,7 @@ export type LayoutOverrides = Partial<
   | HierarchicalLayoutInputs
 >;
 
-const FORCE_LAYOUTS = [
+export const FORCE_LAYOUTS = [
   'forceDirected2d',
   'treeTd2d',
   'treeLr2d',
@@ -37,7 +37,8 @@ export function layoutProvider({
         dimensions: 2,
         nodeLevelRatio: nodeLevelRatio || 2,
         nodeStrength: nodeStrength || -250,
-        linkDistance
+        linkDistance,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'treeTd2d') {
       return forceDirected({
@@ -46,7 +47,8 @@ export function layoutProvider({
         dimensions: 2,
         nodeLevelRatio: nodeLevelRatio || 5,
         nodeStrength: nodeStrength || -250,
-        linkDistance: linkDistance || 50
+        linkDistance: linkDistance || 50,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'treeLr2d') {
       return forceDirected({
@@ -55,7 +57,8 @@ export function layoutProvider({
         dimensions: 2,
         nodeLevelRatio: nodeLevelRatio || 5,
         nodeStrength: nodeStrength || -250,
-        linkDistance: linkDistance || 50
+        linkDistance: linkDistance || 50,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'radialOut2d') {
       return forceDirected({
@@ -64,7 +67,8 @@ export function layoutProvider({
         dimensions: 2,
         nodeLevelRatio: nodeLevelRatio || 5,
         nodeStrength: nodeStrength || -500,
-        linkDistance: linkDistance || 100
+        linkDistance: linkDistance || 100,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'treeTd3d') {
       return forceDirected({
@@ -82,7 +86,8 @@ export function layoutProvider({
         dimensions: 3,
         nodeLevelRatio: nodeLevelRatio || 2,
         nodeStrength: nodeStrength || -500,
-        linkDistance: linkDistance || 50
+        linkDistance: linkDistance || 50,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'radialOut3d') {
       return forceDirected({
@@ -91,7 +96,8 @@ export function layoutProvider({
         dimensions: 3,
         nodeLevelRatio: nodeLevelRatio || 2,
         nodeStrength: nodeStrength || -500,
-        linkDistance: linkDistance || 100
+        linkDistance: linkDistance || 100,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     } else if (type === 'forceDirected3d') {
       return forceDirected({
@@ -99,7 +105,8 @@ export function layoutProvider({
         dimensions: 3,
         nodeLevelRatio: nodeLevelRatio || 2,
         nodeStrength: nodeStrength || -250,
-        linkDistance
+        linkDistance,
+        forceLayout: type
       } as ForceDirectedLayoutInputs);
     }
   } else if (type === 'circular2d') {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Improvement
```

## What is the new behavior?
Better spacing on `forceDirected2d` graphs

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
e.g. of 1000 nodes

BEFORE
![Screenshot 2024-02-21 at 5 26 13 PM](https://github.com/reaviz/reagraph/assets/40581813/d71e14bc-8a3a-4411-8cd9-eff02a9de2b1)


AFTER
![Screenshot 2024-02-21 at 5 25 46 PM](https://github.com/reaviz/reagraph/assets/40581813/b15284c7-3624-447d-8218-22ac664651ef)


This also affected some medium sized graphs like below. The "before" debatably looks better here tho 😅 

BEFORE
![image](https://github.com/reaviz/reagraph/assets/40581813/03ad7aaf-b370-461a-bb6d-92032d4f9261)

AFTER
![image](https://github.com/reaviz/reagraph/assets/40581813/3d3d2a3a-89cc-4897-8756-cb04998c9886)
