### PR TITLE
Fix nodes moving on initial hover

### DIFF
--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -85,7 +85,7 @@ export interface ForceDirectedLayoutInputs extends LayoutFactoryProps {
   forceLayout: (typeof FORCE_LAYOUTS)[number];
 }
 
-const TICK_COUNT = 100;
+const TICK_COUNT = 200;
 
 export function forceDirected({
   graph,
@@ -209,7 +209,7 @@ export function forceDirected({
 
   return {
     step() {
-      // Run the ticker 100 times so
+      // Run the ticker 200 times so
       // we don't overdo the animation
       sim.tick(TICK_COUNT);
       return true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sometimes nodes move on the initial interaction (hover or click). It tends to happen on bigger graphs

## What is the new behavior?
Nodes don't move on initial interaction


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Larger graphs were stopping before the full animation on initial load was complete. Then they would continue that animation when you interact. This doubles the ticks so the animation can finish
