### PR TITLE
Fix 2d graph over-rotating on node select

### DIFF
--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -6,7 +6,7 @@ import { useHotkeys } from 'reakeys';
 import { getLayoutCenter } from '../utils/layout';
 import { InternalGraphNode } from '../types';
 import { useStore } from '../store';
-import { isNodeInView } from './utils';
+import { isNodeInView, getDegreesToClosest2dAxis } from './utils';
 import { LayoutTypes } from 'layout/types';
 
 const PADDING = 50;
@@ -71,7 +71,13 @@ export const useCenterGraph = ({
 
         // Check whether the layout is 3d or not to adjust centering logic
         if (!layoutType.includes('3d')) {
-          void controls?.rotateTo(0, Math.PI / 2, true);
+          const { horizontalRotation, verticalRotation } =
+            getDegreesToClosest2dAxis(
+              controls?.azimuthAngle,
+              controls?.polarAngle
+            );
+
+          void controls?.rotate(horizontalRotation, verticalRotation, true);
         }
 
         await controls?.fitToBox(

--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -69,8 +69,9 @@ export const useCenterGraph = ({
         const { minX, maxX, minY, maxY, minZ, maxZ, x, y, z } =
           getLayoutCenter(centerNodes);
 
-        // Check whether the layout is 3d or not to adjust centering logic
         if (!layoutType.includes('3d')) {
+          // fitToBox will auto rotate to the closest axis including the z axis, which is not desired for 2D graphs
+          // So get the rotation to the closest flat axis for 2D graphs
           const { horizontalRotation, verticalRotation } =
             getDegreesToClosest2dAxis(
               controls?.azimuthAngle,

--- a/src/CameraControls/utils.test.ts
+++ b/src/CameraControls/utils.test.ts
@@ -1,0 +1,45 @@
+import { expect, test, describe } from 'vitest';
+import { getClosestAxis, getDegreesToClosest2dAxis } from './utils';
+
+describe('getDegreesToClosest2dAxis', () => {
+  test('should return the correct rotations for given angles', () => {
+    const result = getDegreesToClosest2dAxis(0.1, 3.1);
+
+    expect(result).toEqual({
+      horizontalRotation: -0.1,
+      verticalRotation: -1.5292036732051035
+    });
+  });
+
+  test('should handle angles greater than 360 degrees', () => {
+    const result = getDegreesToClosest2dAxis(
+      (5 * Math.PI) / 2,
+      (5 * Math.PI) / 2
+    );
+
+    expect(result).toEqual({
+      horizontalRotation: -Math.PI / 2,
+      verticalRotation: 0
+    });
+  });
+});
+
+describe('getClosestAxis', () => {
+  test('should return the closest axis for a given angle', () => {
+    const axes = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
+    const result = getClosestAxis(Math.PI / 3, axes);
+    expect(result).toBe(Math.PI / 2);
+  });
+
+  test('should handle negative angles', () => {
+    const axes = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
+    const result = getClosestAxis(-Math.PI / 4, axes);
+    expect(result).toBe(0);
+  });
+
+  test('should handle angles greater than 360 degrees', () => {
+    const axes = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
+    const result = getClosestAxis((5 * Math.PI) / 2, axes);
+    expect(result).toBe(Math.PI / 2);
+  });
+});

--- a/src/CameraControls/utils.ts
+++ b/src/CameraControls/utils.ts
@@ -51,3 +51,33 @@ export function isNodeInView(
     nodePosition?.y < visibleArea.y1
   );
 }
+
+/**
+ * Get the closest axis to a given angle.
+ */
+export function getClosestAxis(angle: number, axes: number[]) {
+  return axes.reduce((prev, curr) =>
+    Math.abs(curr - (angle % Math.PI)) < Math.abs(prev - (angle % Math.PI))
+      ? curr
+      : prev
+  );
+}
+
+/**
+ * Get how far an angle is from the closest 2D axis in radians.
+ */
+export function getDegreesToClosest2dAxis(
+  horizontalAngle: number,
+  verticalAngle: number
+) {
+  const closestHorizontalAxis = getClosestAxis(horizontalAngle, [0, Math.PI]);
+  const closestVerticalAxis = getClosestAxis(verticalAngle, [
+    Math.PI / 2,
+    (3 * Math.PI) / 2
+  ]);
+
+  return {
+    horizontalRotation: closestHorizontalAxis - (horizontalAngle % Math.PI),
+    verticalRotation: closestVerticalAxis - (verticalAngle % Math.PI)
+  };
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
2d graphs over-rotate sometimes when selecting or de-selecting a node
Issue Number: #192 


## What is the new behavior?
2d graphs will rotate to the closest flat axis on node selection

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
BEFORE

https://github.com/reaviz/reagraph/assets/40581813/d27e7a59-cbf0-4d09-b94a-274240732707



AFTER

https://github.com/reaviz/reagraph/assets/40581813/7f1710db-9f6f-49d3-bbf8-e9a97d44744d

