### PR TITLE
Fix camera reorient on deselect

### DIFF
--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -63,7 +63,7 @@ export const useCenterGraph = ({
     async (centerNodes: InternalGraphNode[], animated = true) => {
       if (
         centerNodes?.some(node => !isNodeInView(camera, node.position)) ||
-        centerNodes?.length === nodes?.length
+        !mounted.current
       ) {
         // Centers the graph based on the central most node
         const { minX, maxX, minY, maxY, minZ, maxZ, x, y, z } =


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The camera re-orients on de-select even when it's not necessary - all nodes are in view

Issue Number: #194 

## What is the new behavior?
The camera doesn't re-orient when all nodes are in view

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

BEFORE

https://github.com/reaviz/reagraph/assets/40581813/5ee72477-fec7-42a4-9294-cb8bd69fc284


AFTER


https://github.com/reaviz/reagraph/assets/40581813/da804423-9a0e-4703-be9a-a45810c85062


