### PR TITLE
Fix camera moving slightly on drag

### DIFF
--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -203,12 +203,10 @@ export const Node: FC<NodeProps> = ({
     onDragStart: () => {
       setDraggingId(id);
       setActive(true);
-      cameraControls.controls.enabled = false;
     },
     onDragEnd: () => {
       setDraggingId(null);
       setActive(false);
-      cameraControls.controls.enabled = true;
       onDragged?.(node);
     }
   });
@@ -228,10 +226,12 @@ export const Node: FC<NodeProps> = ({
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled: disabled || isDragging,
     onPointerOver: () => {
+      cameraControls.controls.enabled = false;
       setActive(true);
       onPointerOver?.(node);
     },
     onPointerOut: () => {
+      cameraControls.controls.enabled = true;
       setActive(false);
       onPointerOut?.(node);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Camera moves slightly after releasing a dragged node

Issue Number: #193 


## What is the new behavior?
Camera doesn't move after releasing a drag

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
What seemed to be happening here is -> inside the drag function the camera controls get disabled, but the drag doesn't actually trigger until after you've started dragging your cursor a bit. This means the camera starts panning THEN the drag begins.

I think the camera moving on drag release is a continuation of the momentum from when the camera pan started before the drag

**This change disables camera controls on node hover instead of on node drag**

Note: If you start dragging the node so quickly that the hover isn't recognized then you can get the camera to move after releasing

BEFORE

https://github.com/reaviz/reagraph/assets/40581813/f55c9eca-6be4-43d5-b8d3-7a359e0417d5

AFTER

https://github.com/reaviz/reagraph/assets/40581813/5774fb21-6c04-473a-9416-9ec306e941a6




