### PR TITLE
Re-center camera when nodes update

### DIFF
--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -139,11 +139,14 @@ export const useCenterGraph = ({
       if (controls && nodes?.length && !mounted.current) {
         await centerNodes(nodes, false);
         mounted.current = true;
+        // If node positions have changed and some aren't in view, center the graph
+      } else if (controls && nodes?.length) {
+        await centerNodes(nodes, animated);
       }
     }
 
     load();
-  }, [controls, centerNodes, nodes]);
+  }, [controls, centerNodes, nodes, animated]);
 
   useHotkeys([
     {

--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -135,13 +135,16 @@ export const useCenterGraph = ({
 
   useLayoutEffect(() => {
     async function load() {
-      // Center the graph once nodes are loaded on mount
-      if (controls && nodes?.length && !mounted.current) {
-        await centerNodes(nodes, false);
-        mounted.current = true;
-        // If node positions have changed and some aren't in view, center the graph
-      } else if (controls && nodes?.length) {
-        await centerNodes(nodes, animated);
+      // Once we've loaded controls and we have nodes, let's recenter
+      if (controls && nodes?.length) {
+        if (!mounted.current) {
+          // Center the graph once nodes are loaded on mount
+          await centerNodes(nodes, false);
+          mounted.current = true;
+        } else {
+          // If node positions have changed and some aren't in view, center the graph
+          await centerNodes(nodes, animated);
+        }
       }
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When node positions change (from dragging, layout change, etc.) they can sometimes go outside the camera's view. Then the user has to pan the camera around to look for the graph


## What is the new behavior?
The camera re-centers on the graph when node positions change and any are out of view

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

BEFORE


https://github.com/reaviz/reagraph/assets/40581813/e90f47a0-ca82-4b77-b6ba-e4670c434f52


https://github.com/reaviz/reagraph/assets/40581813/b2297b2a-f9d6-4596-8baa-2437513fea58


AFTER


https://github.com/reaviz/reagraph/assets/40581813/c98bb342-f52f-4329-acf6-2a6364b12976


https://github.com/reaviz/reagraph/assets/40581813/6278c8f6-c148-4759-893e-47462b00c1b7

