### PR TITLE
Fix can't zoom while hovering a node

### DIFF
--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -226,12 +226,12 @@ export const Node: FC<NodeProps> = ({
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled: disabled || isDragging,
     onPointerOver: () => {
-      cameraControls.controls.enabled = false;
+      cameraControls.controls.truckSpeed = 0;
       setActive(true);
       onPointerOver?.(node);
     },
     onPointerOut: () => {
-      cameraControls.controls.enabled = true;
+      cameraControls.controls.truckSpeed = 2.0;
       setActive(false);
       onPointerOut?.(node);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
You can't zoom the camera while hovering a node


## What is the new behavior?
You can zoom while hovering a node

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The camera controls were being entirely disabled while hovering a node. Set the truckSpeed to 0 instead ("Speed of drag for truck and pedestal")