### PR TITLE
Fix zoom to cursor

### DIFF
--- a/src/CameraControls/CameraControls.tsx
+++ b/src/CameraControls/CameraControls.tsx
@@ -224,7 +224,7 @@ export const CameraControls: FC<
       } else {
         cameraRef.current.mouseButtons.left = 2;
         cameraRef.current.mouseButtons.middle = 2;
-        cameraRef.current.mouseButtons.wheel = 16;
+        cameraRef.current.mouseButtons.wheel = ThreeCameraControls.ACTION.DOLLY;
       }
     }, [disabled]);
 

--- a/src/CameraControls/CameraControls.tsx
+++ b/src/CameraControls/CameraControls.tsx
@@ -218,12 +218,13 @@ export const CameraControls: FC<
 
     useEffect(() => {
       if (disabled) {
-        cameraRef.current.mouseButtons.left = 0;
-        cameraRef.current.mouseButtons.middle = 0;
-        cameraRef.current.mouseButtons.wheel = 0;
+        cameraRef.current.mouseButtons.left = ThreeCameraControls.ACTION.NONE;
+        cameraRef.current.mouseButtons.middle = ThreeCameraControls.ACTION.NONE;
+        cameraRef.current.mouseButtons.wheel = ThreeCameraControls.ACTION.NONE;
       } else {
-        cameraRef.current.mouseButtons.left = 2;
-        cameraRef.current.mouseButtons.middle = 2;
+        cameraRef.current.mouseButtons.left = ThreeCameraControls.ACTION.TRUCK;
+        cameraRef.current.mouseButtons.middle =
+          ThreeCameraControls.ACTION.TRUCK;
         cameraRef.current.mouseButtons.wheel = ThreeCameraControls.ACTION.DOLLY;
       }
     }, [disabled]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The camera only zooms towards the center of the graph

Issue Number: #200 


## What is the new behavior?
When zooming with your mousewheel, the camera zooms towards the cursor 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This switches mouse wheel behavior to dolly instead of zoom

This allows the `dollyToCursor` prop to do its thing

https://github.com/reaviz/reagraph/assets/40581813/582b58d2-5866-494b-8276-a83cad13f5c2


