### PR TITLE
Fix graph only centering when nodes out of view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reagraph",
-  "version": "4.15.18",
+  "version": "4.15.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reagraph",
-      "version": "4.15.18",
+      "version": "4.15.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-spring/three": "9.6.1",
@@ -45,7 +45,7 @@
         "@types/d3-array": "^3.2.1",
         "@types/d3-hierarchy": "^3.1.6",
         "@types/d3-scale": "^4.0.8",
-        "@types/react": "18.2.57",
+        "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
         "@types/three": "^0.154.0",
         "@typescript-eslint/eslint-plugin": "^7.1.0",

--- a/src/GraphCanvas.tsx
+++ b/src/GraphCanvas.tsx
@@ -120,7 +120,8 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
       const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
       useImperativeHandle(ref, () => ({
-        centerGraph: (n?: string[]) => rendererRef.current?.centerGraph(n),
+        centerGraph: (n?: string[], centerIfNodesNotInView?: boolean) =>
+          rendererRef.current?.centerGraph(n, centerIfNodesNotInView),
         zoomIn: () => controlsRef.current?.zoomIn(),
         zoomOut: () => controlsRef.current?.zoomOut(),
         panLeft: () => controlsRef.current?.panLeft(),

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -233,7 +233,7 @@ export interface GraphSceneRef {
   /**
    * Center the graph on a node or list of nodes.
    */
-  centerGraph: (ids?: string[]) => void;
+  centerGraph: (ids?: string[], centerIfNodesNotInView?: boolean) => void;
 
   /**
    * Calls render scene on the graph. this is useful when you want to manually render the graph

--- a/src/selection/useSelection.ts
+++ b/src/selection/useSelection.ts
@@ -266,7 +266,8 @@ export const useSelection = ({
           [data.id],
           pathSelectionType
         );
-        ref.current?.centerGraph([data.id, ...adjacents]);
+
+        ref.current?.centerGraph([data.id, ...adjacents], true);
       }
     },
     [
@@ -349,7 +350,7 @@ export const useSelection = ({
             throw new Error('No ref found for the graph canvas.');
           }
 
-          ref.current?.centerGraph();
+          ref.current?.centerGraph([], true);
         }
       }
     },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The graph will only center if a node is out of view, even when trying to center manually from a control button


## What is the new behavior?
The graph centers when triggering manually with controls

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
BEFORE

https://github.com/reaviz/reagraph/assets/40581813/469417a7-58c2-41a4-bb30-506a955ae1e1


AFTER

https://github.com/reaviz/reagraph/assets/40581813/19a225e1-62c3-4a2f-a971-a54faca692fe


