### PR TITLE
Fix camera view resetting on label visibility change

### DIFF
--- a/docs/Centering.mdx
+++ b/docs/Centering.mdx
@@ -1,0 +1,69 @@
+import { Meta, Story, ArgsTable } from '@storybook/blocks';
+import { GraphCanvas } from '../src';
+
+<Meta title="Docs/Advanced/Centering" />
+
+# Centering
+Reagraph supports the ability to dynamically center nodes using the `centerGraph` method from the `GraphCanvasRef`. This method allows you to programmatically center the camera view around specific nodes or the entire graph.
+
+### Usage
+First, you need to get a reference to the `GraphRef`:
+
+```jsx
+
+  const graphRef = useRef<GraphCanvasRef | null>(null);
+return (
+    <GraphCanvas ref={graphRef} {...} />
+)
+```
+
+Then, you can use the `centerGraph` method to center all nodes within view of the camera:
+
+```js
+graphRef.current?.centerGraph();
+```
+
+If you want to center the view around specific nodes, you can pass an array of node ids to the `centerGraph` method:
+
+```jsx
+graphRef.current?.centerGraph(['node1', 'node2']);
+```
+
+### Examples
+In this example, clicking the "Center Graph" button will center the camera around all the nodes in the graph:
+```jsx
+import React, { useRef } from 'react';
+import { GraphCanvas } from 'reagraph';
+
+const MyComponent = () => {
+  const graphRef = useRef<GraphCanvasRef | null>(null);
+
+  const centerGraph = () => {
+    graphRef.current?.centerGraph();
+  };
+
+  return (
+    <div>
+      <GraphCanvas ref={graphRef} {...} />
+      <button onClick={centerGraph}>Center Graph</button>
+    </div>
+  );
+};
+```
+
+
+Here's a more advanced example that centers the camera on the whole graph whenever new nodes are added:
+```jsx
+import React, { useRef, useEffect } from 'react';
+import { GraphCanvas } from 'reagraph';
+
+const MyComponent = ({ nodes }) => {
+  const graphRef = useRef<GraphCanvasRef | null>(null);
+
+  useEffect(() => {
+    graphRef.current?.centerGraph();
+  }, [nodes]);
+
+  return <GraphCanvas ref={graphRef} {...} />;
+};
+```

--- a/docs/demos/Basic.story.tsx
+++ b/docs/demos/Basic.story.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { GraphCanvas, GraphCanvasRef, lightTheme } from '../../src';
 import { parentEdges, parentNodes, simpleEdges, simpleNodes, random } from '../assets/demo';
 import { range } from 'd3-array';
@@ -100,8 +100,14 @@ export const Many = () => (
 );
 
 export const LiveUpdates = () => {
+  const ref = useRef<GraphCanvasRef | null>(null);
   const [nodes, setNodes] = useState(simpleNodes);
   const [edges, setEdges] = useState(simpleEdges);
+
+  useEffect(() => {
+    ref.current?.centerGraph();
+  }, [nodes]);
+
   return (
     <div>
       <div style={{ zIndex: 9, position: 'absolute', top: 15, right: 15, background: 'rgba(0, 0, 0, .5)', padding: 1, color: 'white' }}>
@@ -126,7 +132,7 @@ export const LiveUpdates = () => {
           Remove Node {nodes[0]?.id}
         </button>
       </div>
-      <GraphCanvas nodes={nodes} edges={edges} />
+      <GraphCanvas ref={ref} nodes={nodes} edges={edges} />
     </div>
   );
 };

--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -178,12 +178,6 @@ export const useCenterGraph = ({
           // Center the graph once nodes are loaded on mount
           await centerNodes(nodes, { animated: false });
           mounted.current = true;
-        } else {
-          // If node positions have changed and some aren't in view, center the graph
-          await centerNodes(nodes, {
-            animated,
-            centerOnlyIfNodesNotInView: true
-          });
         }
       }
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The camera resets while zooming in on a big graph when label visibility switches

The camera also resets while dragging nodes when other nodes are out view. 

Issue Number: #213 #214 


## What is the new behavior?
The camera doesn't re-center automatically when nodes/labels update. Centering the camera is now left to be handled on a case-by-case basis using the `centerGraph` method from `GraphCanvasRef`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The `node.labelVisible` field was triggering a re-render when it updated that would cause the camera to re-center if any nodes were out of view. Same thing was happening when dragging a node which updates `node.position`


BEFORE

https://github.com/reaviz/reagraph/assets/40581813/a0bbfbc1-a57e-4dba-8611-3cf37fe71326




AFTER


https://github.com/reaviz/reagraph/assets/40581813/59825fcb-a978-4a34-b028-e7c0ab8b44a3

