### PR TITLE
Expose events for Click and Pointer API

### DIFF
--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -34,8 +34,7 @@ import { CenterNodesParams, useCenterGraph } from './CameraControls';
 import { LabelVisibilityType } from './utils';
 import { useStore } from './store';
 import Graph from 'graphology';
-import { useThree } from '@react-three/fiber';
-import { WebGLRenderer } from 'three';
+import { ThreeEvent, useThree } from '@react-three/fiber';
 
 export interface GraphSceneProps {
   /**
@@ -158,12 +157,19 @@ export interface GraphSceneProps {
   /**
    * When a node was clicked.
    */
-  onNodeClick?: (node: InternalGraphNode, props?: CollapseProps) => void;
+  onNodeClick?: (
+    node: InternalGraphNode,
+    props?: CollapseProps,
+    event?: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
    * When a node was double clicked.
    */
-  onNodeDoubleClick?: (node: InternalGraphNode) => void;
+  onNodeDoubleClick?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
    * When a node context menu happened.
@@ -176,12 +182,18 @@ export interface GraphSceneProps {
   /**
    * When node got a pointer over.
    */
-  onNodePointerOver?: (node: InternalGraphNode) => void;
+  onNodePointerOver?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * When node lost pointer over.
    */
-  onNodePointerOut?: (node: InternalGraphNode) => void;
+  onNodePointerOut?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * Triggered after a node was dragged.
@@ -196,32 +208,50 @@ export interface GraphSceneProps {
   /**
    * When an edge was clicked.
    */
-  onEdgeClick?: (edge: InternalGraphEdge) => void;
+  onEdgeClick?: (
+    edge: InternalGraphEdge,
+    event?: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
    * When edge got a pointer over.
    */
-  onEdgePointerOver?: (edge: InternalGraphEdge) => void;
+  onEdgePointerOver?: (
+    edge: InternalGraphEdge,
+    event?: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * When edge lost pointer over.
    */
-  onEdgePointerOut?: (edge: InternalGraphEdge) => void;
+  onEdgePointerOut?: (
+    edge: InternalGraphEdge,
+    event?: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * When a cluster was clicked.
    */
-  onClusterClick?: (cluster: ClusterEventArgs) => void;
+  onClusterClick?: (
+    cluster: ClusterEventArgs,
+    event: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
-   * When a cluster recieves a pointer over event.
+   * When a cluster receives a pointer over event.
    */
-  onClusterPointerOver?: (cluster: ClusterEventArgs) => void;
+  onClusterPointerOver?: (
+    cluster: ClusterEventArgs,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
-   * When cluster recieves a pointer leave event.
+   * When cluster receives a pointer leave event.
    */
-  onClusterPointerOut?: (cluster: ClusterEventArgs) => void;
+  onClusterPointerOut?: (
+    cluster: ClusterEventArgs,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 }
 
 export interface GraphSceneRef {

--- a/src/symbols/Cluster.tsx
+++ b/src/symbols/Cluster.tsx
@@ -5,6 +5,7 @@ import { Color, DoubleSide } from 'three';
 import { useStore } from '../store';
 import { Label } from './Label';
 import { useCursor } from 'glodrei';
+import { ThreeEvent } from '@react-three/fiber';
 
 export type ClusterEventArgs = Omit<ClusterGroup, 'position'>;
 
@@ -37,17 +38,23 @@ export interface ClusterProps extends ClusterGroup {
   /**
    * When the cluster was clicked.
    */
-  onClick?: (cluster: ClusterEventArgs) => void;
+  onClick?: (cluster: ClusterEventArgs, event: ThreeEvent<MouseEvent>) => void;
 
   /**
-   * When a cluster recieves a pointer over event.
+   * When a cluster receives a pointer over event.
    */
-  onPointerOver?: (cluster: ClusterEventArgs) => void;
+  onPointerOver?: (
+    cluster: ClusterEventArgs,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
-   * When cluster recieves a pointer leave event.
+   * When cluster receives a pointer leave event.
    */
-  onPointerOut?: (cluster: ClusterEventArgs) => void;
+  onPointerOut?: (
+    cluster: ClusterEventArgs,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 }
 
 export const Cluster: FC<ClusterProps> = ({
@@ -116,19 +123,25 @@ export const Cluster: FC<ClusterProps> = ({
 
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled,
-    onPointerOver: () => {
+    onPointerOver: (event: ThreeEvent<PointerEvent>) => {
       setActive(true);
-      onPointerOver?.({
-        nodes,
-        label
-      });
+      onPointerOver?.(
+        {
+          nodes,
+          label
+        },
+        event
+      );
     },
-    onPointerOut: () => {
+    onPointerOut: (event: ThreeEvent<PointerEvent>) => {
       setActive(false);
-      onPointerOut?.({
-        nodes,
-        label
-      });
+      onPointerOut?.(
+        {
+          nodes,
+          label
+        },
+        event
+      );
     }
   });
 
@@ -139,12 +152,15 @@ export const Cluster: FC<ClusterProps> = ({
           position={circlePosition as any}
           onPointerOver={pointerOver}
           onPointerOut={pointerOut}
-          onClick={() => {
+          onClick={(event: ThreeEvent<MouseEvent>) => {
             if (!disabled) {
-              onClick?.({
-                nodes,
-                label
-              });
+              onClick?.(
+                {
+                  nodes,
+                  label
+                },
+                event
+              );
             }
           }}
         >

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -18,6 +18,7 @@ import { ContextMenuEvent, InternalGraphEdge } from '../types';
 import { Html, useCursor } from 'glodrei';
 import { useHoverIntent } from '../utils/useHoverIntent';
 import { Euler, Vector3 } from 'three';
+import { ThreeEvent } from '@react-three/fiber';
 
 /**
  * Label positions relatively edge.
@@ -81,7 +82,7 @@ export interface EdgeProps {
   /**
    * A function that is called when the edge is clicked.
    */
-  onClick?: (edge: InternalGraphEdge) => void;
+  onClick?: (edge: InternalGraphEdge, event: ThreeEvent<MouseEvent>) => void;
 
   /**
    * A function that is called when the edge is right-clicked.
@@ -91,12 +92,18 @@ export interface EdgeProps {
   /**
    * A function that is called when the mouse pointer is moved over the edge.
    */
-  onPointerOver?: (edge: InternalGraphEdge) => void;
+  onPointerOver?: (
+    edge: InternalGraphEdge,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * A function that is called when the mouse pointer is moved out of the edge.
    */
-  onPointerOut?: (edge: InternalGraphEdge) => void;
+  onPointerOut?: (
+    edge: InternalGraphEdge,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 }
 
 const LABEL_PLACEMENT_OFFSET = 3;
@@ -253,13 +260,13 @@ export const Edge: FC<EdgeProps> = ({
 
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled,
-    onPointerOver: () => {
+    onPointerOver: (event: ThreeEvent<PointerEvent>) => {
       setActive(true);
-      onPointerOver?.(edge);
+      onPointerOver?.(edge, event);
     },
-    onPointerOut: () => {
+    onPointerOut: (event: ThreeEvent<PointerEvent>) => {
       setActive(false);
-      onPointerOut?.(edge);
+      onPointerOut?.(edge, event);
     }
   });
 
@@ -369,9 +376,9 @@ export const Edge: FC<EdgeProps> = ({
         id={id}
         opacity={selectionOpacity}
         size={size}
-        onClick={() => {
+        onClick={event => {
           if (!disabled) {
-            onClick?.(edge);
+            onClick?.(edge, event);
           }
         }}
         onPointerOver={pointerOver}

--- a/src/symbols/Line.tsx
+++ b/src/symbols/Line.tsx
@@ -50,7 +50,7 @@ export interface LineProps {
   /**
    * A function that is called when the line is clicked.
    */
-  onClick?: () => void;
+  onClick?: (event: ThreeEvent<MouseEvent>) => void;
 
   /**
    * A function that is called when the line is right-clicked.

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -25,6 +25,7 @@ import { useStore } from '../store';
 import { useDrag } from '../utils/useDrag';
 import { Icon } from './nodes';
 import { useHoverIntent } from '../utils/useHoverIntent';
+import { ThreeEvent } from '@react-three/fiber';
 
 export interface NodeProps {
   /**
@@ -70,22 +71,35 @@ export interface NodeProps {
   /**
    * The function to call when the pointer is over the node.
    */
-  onPointerOver?: (node: InternalGraphNode) => void;
+  onPointerOver?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * The function to call when the pointer is out of the node.
    */
-  onPointerOut?: (node: InternalGraphNode) => void;
+  onPointerOut?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<PointerEvent>
+  ) => void;
 
   /**
    * The function to call when the node is clicked.
    */
-  onClick?: (node: InternalGraphNode, props?: CollapseProps) => void;
+  onClick?: (
+    node: InternalGraphNode,
+    props?: CollapseProps,
+    event?: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
    * The function to call when the node is double clicked.
    */
-  onDoubleClick?: (node: InternalGraphNode) => void;
+  onDoubleClick?: (
+    node: InternalGraphNode,
+    event: ThreeEvent<MouseEvent>
+  ) => void;
 
   /**
    * The function to call when the node is right clicked.
@@ -225,15 +239,15 @@ export const Node: FC<NodeProps> = ({
 
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled: disabled || isDragging,
-    onPointerOver: () => {
+    onPointerOver: (event: ThreeEvent<PointerEvent>) => {
       cameraControls.controls.truckSpeed = 0;
       setActive(true);
-      onPointerOver?.(node);
+      onPointerOver?.(node, event);
     },
-    onPointerOut: () => {
+    onPointerOut: (event: ThreeEvent<PointerEvent>) => {
       cameraControls.controls.truckSpeed = 2.0;
       setActive(false);
-      onPointerOut?.(node);
+      onPointerOut?.(node, event);
     }
   });
 
@@ -370,17 +384,21 @@ export const Node: FC<NodeProps> = ({
       position={nodePosition as any}
       onPointerOver={pointerOver}
       onPointerOut={pointerOut}
-      onClick={() => {
+      onClick={(event: ThreeEvent<MouseEvent>) => {
         if (!disabled && !isDragging) {
-          onClick?.(node, {
-            canCollapse,
-            isCollapsed
-          });
+          onClick?.(
+            node,
+            {
+              canCollapse,
+              isCollapsed
+            },
+            event
+          );
         }
       }}
-      onDoubleClick={() => {
+      onDoubleClick={(event: ThreeEvent<MouseEvent>) => {
         if (!disabled && !isDragging) {
-          onDoubleClick?.(node);
+          onDoubleClick?.(node, event);
         }
       }}
       onContextMenu={() => {


### PR DESCRIPTION
This PR:
- adds events for Click and Pointer (hover) callback API for Nodes, Edges and Clusters (see discussion https://github.com/reaviz/reagraph/discussions/221)
- fixes some typos

Issues and inconsistencies I couldn't decide on my own:
- exposing ThreeEvent types feels like a bad smell to me. It cant be casted to vanilla event because it lacks some attributes. Also consider onCanvasClick has vanilla MouseEvent as an argument already. Solutions could be casting to intersection between ThreeEvent and vanilla event and/or reexporting ThreeEvents under new alias.
- because of edge intersection (see Edges.tsx) I could not make event argument non-optional for onEdge... events
- because of existing optional second argument for onNodeClick I had to make event argument also optional. I suggest considering making second argument non-optional so event can also be guaranteed. Changing order of arguments would break some existing code.