### PR TITLE
Fix Edge context menu position

### DIFF
--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -354,11 +354,11 @@ export const Edge: FC<EdgeProps> = ({
     () =>
       menuVisible &&
       contextMenu && (
-        <Html prepend={true} center={true}>
+        <Html prepend={true} center={true} position={midPoint}>
           {contextMenu({ data: edge, onClose: () => setMenuVisible(false) })}
         </Html>
       ),
-    [menuVisible, contextMenu, edge]
+    [menuVisible, contextMenu, midPoint, edge]
   );
 
   return (


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When opening the `context menu` on Edges (the ones used when animation is on), the menu is not centered on the Edge line

<img width="1141" alt="image" src="https://github.com/reaviz/reagraph/assets/111360279/05f071b5-b131-4272-99db-67de3dcde9a0">

Issue Number: N/A


## What is the new behavior?
The context menu is centered on the Edge line

<img width="1141" alt="image" src="https://github.com/reaviz/reagraph/assets/111360279/309f0b74-8f2f-44a7-be49-0082933b41ee">

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
