### PR TITLE
Fix eslint setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,11 @@ module.exports = {
     'ecmaVersion': 12,
     'sourceType': 'module'
   },
+  'settings': {
+    'react': {
+      'version': 'detect'
+    }
+  },
   'plugins': ['react', '@typescript-eslint'],
   'rules': {
     'no-prototype-builtins': 'off',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "vitest --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "prettier": "prettier --loglevel warn --write 'src/**/*.{ts,tsx,js,jsx}'",
-    "lint": "eslint --ext js,ts,tsx",
+    "lint": "eslint --ext js,ts,tsx src",
     "lint:fix": "eslint --ext js,ts,tsx --fix src",
     "start": "storybook dev -p 9009",
     "build-storybook": "storybook build",


### PR DESCRIPTION
## PR Type
[x] Bugfix
[x] Refactoring (no functional changes, no api changes)
[x] Build related changes
[x] CI related changes

## What is the current behavior?
eslint was not running properly in VSCode Windows. Missing target source directory in package.json was preventing linter from finding issues. After fixing that got warning about missing react version in eslint config. This is fixed in PR as well

## What is the new behavior?
Works fine for my setup (VS Code on Windows). If error is introduced 'npm run' lint correctly identifies it

## Does this PR introduce a breaking change?
No, but could affect build actions.