### PR TITLE
Fix label rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reagraph",
-  "version": "4.15.27",
+  "version": "4.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reagraph",
-      "version": "4.15.27",
+      "version": "4.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-spring/three": "9.6.1",

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -317,7 +317,7 @@ export const Edge: FC<EdgeProps> = ({
     () =>
       labelVisible &&
       label && (
-        <a.group position={labelPosition as any} rotation={labelRotation}>
+        <a.group position={labelPosition as any}>
           <Label
             text={label}
             ellipsis={15}
@@ -330,6 +330,7 @@ export const Edge: FC<EdgeProps> = ({
             }
             opacity={selectionOpacity}
             fontSize={theme.edge.label.fontSize}
+            rotation={labelRotation}
           />
         </a.group>
       ),

--- a/src/symbols/Label.tsx
+++ b/src/symbols/Label.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo } from 'react';
 import { Billboard, Text } from 'glodrei';
-import { Color, ColorRepresentation } from 'three';
+import { Color, ColorRepresentation, Euler } from 'three';
 import ellipsize from 'ellipsize';
 
 export interface LabelProps {
@@ -44,6 +44,11 @@ export interface LabelProps {
    * Whether the label is active ( dragging, hover, focus ).
    */
   active?: boolean;
+
+  /**
+   * Rotation of the label.
+   */
+  rotation?: Euler | [number, number, number];
 }
 
 export const Label: FC<LabelProps> = ({
@@ -54,7 +59,8 @@ export const Label: FC<LabelProps> = ({
   opacity,
   stroke,
   active,
-  ellipsis
+  ellipsis,
+  rotation
 }) => {
   const shortText = ellipsis && !active ? ellipsize(text, ellipsis) : text;
   const normalizedColor = useMemo(() => new Color(color), [color]);
@@ -76,6 +82,7 @@ export const Label: FC<LabelProps> = ({
         depthOffset={0}
         maxWidth={100}
         overflowWrap="break-word"
+        rotation={rotation}
       >
         {shortText}
       </Text>

--- a/src/symbols/edges/Edge.tsx
+++ b/src/symbols/edges/Edge.tsx
@@ -147,7 +147,7 @@ export const Edge: FC<EdgeProps> = ({
   return (
     <group>
       {labelVisible && label && (
-        <a.group position={labelPosition as any} rotation={labelRotation}>
+        <a.group position={labelPosition as any}>
           <Label
             text={label}
             ellipsis={15}
@@ -156,6 +156,7 @@ export const Edge: FC<EdgeProps> = ({
             color={color}
             opacity={opacity}
             fontSize={theme.edge.label.fontSize}
+            rotation={labelRotation}
           />
         </a.group>
       )}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the `GraphScene` prop `edgeLabelPosition` values `inline`, `below`, and `above` don't display the label parallel to the edge - they should


## What is the new behavior?
`edgeLabelPosition`'s behave as expected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is a regression that happened from commit 4c2d0b4c4dd62af4845faf7d0886a97cf33786f7

Not positive why that package upgrade caused it, but applying the label rotation to the underlying `<Text>` instead of the group fixes

BEFORE
![image](https://github.com/reaviz/reagraph/assets/40581813/c97371c3-a5df-436d-a7ab-c85a13326678)

AFTER
![image](https://github.com/reaviz/reagraph/assets/40581813/b03c3675-f6aa-4cad-b283-10e7847ad6f4)
