### PR TITLE
Fix jerky layout switching

### DIFF
--- a/src/layout/forceDirected.ts
+++ b/src/layout/forceDirected.ts
@@ -5,7 +5,8 @@ import {
   forceManyBody as d3ForceManyBody,
   forceX as d3ForceX,
   forceY as d3ForceY,
-  forceZ as d3ForceZ
+  forceZ as d3ForceZ,
+  forceCenter as d3ForceCenter
 } from 'd3-force-3d';
 import { forceRadial, DagMode } from './forceUtils';
 import { LayoutFactoryProps, LayoutStrategy } from './types';
@@ -123,6 +124,7 @@ export function forceDirected({
 
   // Create the simulation
   const sim = d3ForceSimulation()
+    .force('center', d3ForceCenter(0, 0))
     .force('link', d3ForceLink())
     .force('charge', d3ForceManyBody().strength(nodeStrengthAdjustment))
     .force('x', forceX)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Graphs sometimes fly to entirely different locations when switching the layout type


## What is the new behavior?
Different graph layouts stay centered on the same origin

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This centers all graph simulations on (0,0) so they don't fly across the view when you switch the layout

BEFORE

https://github.com/reaviz/reagraph/assets/40581813/79f71871-a9b2-4d27-8c75-8a6c57d82afe


AFTER

https://github.com/reaviz/reagraph/assets/40581813/594c6730-2c1d-48e2-bc06-aef5498ea9a9

