### PR TITLE
Fix fit view bug after panning and zooming

### DIFF
--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -161,7 +161,7 @@ export const useCenterGraph = ({
           void controls?.rotate(horizontalRotation, verticalRotation, true);
         }
 
-        void controls?.zoomTo(1, opts?.animated);
+        await controls?.zoomTo(1, opts?.animated);
 
         await controls?.fitToBox(
           new Box3(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you pan and zoom, then fit nodes to the view, sometimes the view doesn't fit properly


## What is the new behavior?
The view always fits properly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This awaits the zoom reset before positioning the camera when triggering `fitNodesInView`. Now there's a visual split between zooming and positioning the camera, but it's better than the view not being fit to the nodes properly

BEFORE
(happened on the 3rd fit to view trigger)

https://github.com/reaviz/reagraph/assets/40581813/9ca3c9fc-bd04-4420-915a-a859c248d97d



AFTER


https://github.com/reaviz/reagraph/assets/40581813/e35b4ffc-b660-4407-b580-bb6323b57587

Note: If you _only_ zoom or _only_ pan, there's no wonky/jumpyness when fitting the view

