### PR TITLE
feat: open edge context menu from label click

### DIFF
--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -317,7 +317,17 @@ export const Edge: FC<EdgeProps> = ({
     () =>
       labelVisible &&
       label && (
-        <a.group position={labelPosition as any}>
+        <a.group
+          position={labelPosition as any}
+          onContextMenu={() => {
+            if (!disabled) {
+              setMenuVisible(true);
+              onContextMenu?.(edge);
+            }
+          }}
+          onPointerOver={pointerOver}
+          onPointerOut={pointerOut}
+        >
           <Label
             text={label}
             ellipsis={15}
@@ -336,6 +346,8 @@ export const Edge: FC<EdgeProps> = ({
       ),
     [
       active,
+      disabled,
+      edge,
       isActive,
       isSelected,
       label,
@@ -343,6 +355,9 @@ export const Edge: FC<EdgeProps> = ({
       labelPosition,
       labelRotation,
       labelVisible,
+      onContextMenu,
+      pointerOut,
+      pointerOver,
       selectionOpacity,
       theme.edge.label.activeColor,
       theme.edge.label.color,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently in order to open the context menu on an edge you have to click the actual edge itself even if a label is present.

Issue Number: N/A


## What is the new behavior?

The edge context menu can be opened when clicking on the label text as well as the edge itself, similar to the existing behaviour for nodes.

https://github.com/user-attachments/assets/f19d35f3-c26a-4b55-8272-a5be50a564af


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
