### PR TITLE
Fix to make Copy/Paste keyboard shortcuts working with useSelection

### DIFF
--- a/src/selection/useSelection.ts
+++ b/src/selection/useSelection.ts
@@ -310,7 +310,7 @@ export const useSelection = ({
   );
 
   const onKeyDown = useCallback((event: KeyboardEvent) => {
-    const element = event.target as any;
+    const element = event.target as HTMLElement;
     const isSafe =
       element.tagName !== 'INPUT' &&
       element.tagName !== 'SELECT' &&
@@ -318,8 +318,9 @@ export const useSelection = ({
       !element.isContentEditable;
 
     const isMeta = event.metaKey || event.ctrlKey;
+    const isSystemShortcut = ['c', 'x', 'v'].includes(event.key.toLowerCase());
 
-    if (isSafe && isMeta) {
+    if (isSafe && isMeta && !isSystemShortcut) {
       event.preventDefault();
       setMetaKeyDown(true);
     }

--- a/src/selection/useSelection.ts
+++ b/src/selection/useSelection.ts
@@ -318,10 +318,8 @@ export const useSelection = ({
       !element.isContentEditable;
 
     const isMeta = event.metaKey || event.ctrlKey;
-    const isSystemShortcut = ['c', 'x', 'v'].includes(event.key.toLowerCase());
 
-    if (isSafe && isMeta && !isSystemShortcut) {
-      event.preventDefault();
+    if (isSafe && isMeta) {
       setMetaKeyDown(true);
     }
   }, []);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

The aim of this PR is to fix issue #272 => Copy/Paste/Refresh keyboard shortcuts not working if using useSelection Hook

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #272


## What is the new behavior?

Copy paste is now working (you can try it for instance on the text 'Hold Cammand/CTRL ....') in the Modifier Key section.

![image](https://github.com/user-attachments/assets/f6377994-2552-4956-95da-71ce32b68150)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
