### PR TITLE
Add "node-size" SizingType to implement "zoom in" selected node

### DIFF
--- a/docs/demos/Sizing.story.tsx
+++ b/docs/demos/Sizing.story.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { GraphCanvas } from '../../src';
 import { simpleEdges, simpleNodes } from '../assets/demo';
 
@@ -12,11 +12,20 @@ export const None = () => (
 );
 
 export const Centrality = () => (
-  <GraphCanvas sizingType="centrality" nodes={simpleNodes} edges={simpleEdges} />
+  <GraphCanvas
+    sizingType="centrality"
+    nodes={simpleNodes}
+    edges={simpleEdges}
+  />
 );
 
-const MinMaxSizesStory = (props) => (
-  <GraphCanvas {...props} sizingType="centrality" nodes={simpleNodes} edges={simpleEdges} />
+const MinMaxSizesStory = props => (
+  <GraphCanvas
+    {...props}
+    sizingType="centrality"
+    nodes={simpleNodes}
+    edges={simpleEdges}
+  />
 );
 
 export const MinMaxSizes = MinMaxSizesStory.bind({});
@@ -39,3 +48,26 @@ export const Attribute = () => (
     edges={simpleEdges}
   />
 );
+
+export const ZoomInSelected = () => {
+  const [selected, setSelected] = useState<string>();
+
+  const nodes = useMemo(() => {
+    return simpleNodes.map(node => ({
+      ...node,
+      size: selected === node.id ? 14 : 7
+    }));
+  }, [selected]);
+
+  return (
+    <GraphCanvas
+      nodes={nodes}
+      draggable
+      edges={[]}
+      sizingType="node-size"
+      selections={selected ? [selected] : []}
+      onNodeClick={node => setSelected(node.id)}
+      onCanvasClick={() => setSelected(undefined)}
+    />
+  );
+};

--- a/src/sizing/nodeSizeProvider.ts
+++ b/src/sizing/nodeSizeProvider.ts
@@ -9,6 +9,7 @@ export type SizingType =
   | 'pagerank'
   | 'centrality'
   | 'attribute'
+  | 'node-size'
   | 'default';
 
 export interface NodeSizeProviderInputs extends SizingStrategyInputs {
@@ -29,7 +30,7 @@ const providers = {
 
 export function nodeSizeProvider({ type, ...rest }: NodeSizeProviderInputs) {
   const provider = providers[type]?.(rest);
-  if (!provider && type !== 'default') {
+  if (!provider && type !== 'default' && type !== 'node-size') {
     throw new Error(`Unknown sizing strategy: ${type}`);
   }
 
@@ -40,7 +41,7 @@ export function nodeSizeProvider({ type, ...rest }: NodeSizeProviderInputs) {
 
   graph.forEachNode((id, node) => {
     let size;
-    if (type === 'default') {
+    if (type === 'default' || type === 'node-size') {
       size = node.size || rest.defaultSize;
     } else {
       size = provider.getSizeForNode(id);
@@ -58,7 +59,7 @@ export function nodeSizeProvider({ type, ...rest }: NodeSizeProviderInputs) {
   });
 
   // Relatively scale the sizes
-  if (type !== 'none') {
+  if (type !== 'none' && type !== 'node-size') {
     const scale = scaleLinear()
       .domain([min, max])
       .rangeRound([minSize, maxSize]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when a selected node has a different size, then another node also decreases the size

https://github.com/user-attachments/assets/cdc2c3a9-2d3b-4552-947f-5f22ff608e2c



## What is the new behavior?
node-size mode, using the size property of the node without "Relatively scaling the sizes"

https://github.com/user-attachments/assets/dfc99dbf-4722-4ac5-8a1b-dbb053627681



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
