### PR TITLE
#290: Edge Sub Label

### DIFF
--- a/docs/DataShapes.mdx
+++ b/docs/DataShapes.mdx
@@ -10,6 +10,7 @@ The graph is made up of 2 basic data shape objects you can pass to the graph.
 - `GraphEdge` - The link between Nodes
 
 ## GraphElementBaseAttributes
+
 ```ts
 export interface GraphElementBaseAttributes<T = any> {
   /**
@@ -28,6 +29,11 @@ export interface GraphElementBaseAttributes<T = any> {
   label?: string;
 
   /**
+   * SubLabel for the element.
+   */
+  subLabel?: string;
+
+  /**
    * Size of the element.
    */
   size?: number;
@@ -40,6 +46,7 @@ export interface GraphElementBaseAttributes<T = any> {
 ```
 
 ## GraphNode
+
 ```ts
 export interface GraphNode extends GraphElementBaseAttributes {
   /**
@@ -55,6 +62,7 @@ export interface GraphNode extends GraphElementBaseAttributes {
 ```
 
 ## GraphEdge
+
 ```ts
 export interface GraphEdge extends GraphElementBaseAttributes {
   /**
@@ -66,5 +74,12 @@ export interface GraphEdge extends GraphElementBaseAttributes {
    * Target ID of the node.
    */
   target: string;
+
+  /**
+   * Placement of the subLabel relative to the main label.
+   * - 'below': Show subLabel below the main label (default)
+   * - 'above': Show subLabel above the main label
+   */
+  subLabelPlacement?: 'below' | 'above';
 }
 ```

--- a/docs/demos/Labels.story.tsx
+++ b/docs/demos/Labels.story.tsx
@@ -63,7 +63,8 @@ export const EdgeSubLabels = () => (
     nodes={[
       { id: '1', label: 'Node 1' },
       { id: '2', label: 'Node 2' },
-      { id: '3', label: 'Node 3' }
+      { id: '3', label: 'Node 3' },
+      { id: '4', label: 'Node 4' },
     ]}
     edges={[
       {
@@ -71,16 +72,21 @@ export const EdgeSubLabels = () => (
         target: '2',
         id: '1-2',
         label: 'Edge 1-2',
-        subLabel: 'Sub Label 1-2',
-        labelVisible: true
+        subLabel: 'Sub Label 1-2'
       },
       {
         source: '1',
         target: '3',
         id: '1-3',
         label: 'Edge 1-3',
-        subLabel: 'Sub Label 1-3',
-        labelVisible: true
+        subLabel: 'Sub Label 1-3'
+      },
+      {
+        source: '4',
+        target: '2',
+        id: '4-2',
+        label: 'Edge 4-2',
+        subLabel: 'Sub Label 4-2'
       }
     ]}
   />

--- a/docs/demos/Labels.story.tsx
+++ b/docs/demos/Labels.story.tsx
@@ -64,7 +64,7 @@ export const EdgeSubLabels = () => (
       { id: '1', label: 'Node 1' },
       { id: '2', label: 'Node 2' },
       { id: '3', label: 'Node 3' },
-      { id: '4', label: 'Node 4' },
+      { id: '4', label: 'Node 4' }
     ]}
     edges={[
       {
@@ -79,7 +79,8 @@ export const EdgeSubLabels = () => (
         target: '3',
         id: '1-3',
         label: 'Edge 1-3',
-        subLabel: 'Sub Label 1-3'
+        subLabel: 'Sub Label 1-3',
+        subLabelPlacement: 'above'
       },
       {
         source: '4',

--- a/docs/demos/Labels.story.tsx
+++ b/docs/demos/Labels.story.tsx
@@ -2,33 +2,33 @@ import React from 'react';
 import { GraphCanvas } from '../../src';
 import { simpleEdges, simpleNodes } from '../assets/demo';
 
-export default {
-  title: 'Demos/Labels',
-  component: GraphCanvas
-};
+export default { title: 'Demos/Labels', component: GraphCanvas };
 
 export const All = () => (
   <GraphCanvas labelType="all" nodes={simpleNodes} edges={simpleEdges} />
 );
 
 export const LongLabels = () => (
-  <GraphCanvas labelType="all" nodes={[
-    {
-      id: '1',
-      label: 'Department of Defense Logistics and Operations',
-    },
-    {
-      id: '2',
-      label: 'The Security Operations of the Cyber Defense System for the United States of America',
-    }
-  ]} edges={[
-  {
-    id: '1-2',
-    source: '1',
-    target: '2',
-    label: 'The Security Operations of the Cyber Defense System for the United States of America'
-  }
-  ]} />
+  <GraphCanvas
+    labelType="all"
+    nodes={[
+      { id: '1', label: 'Department of Defense Logistics and Operations' },
+      {
+        id: '2',
+        label:
+          'The Security Operations of the Cyber Defense System for the United States of America'
+      }
+    ]}
+    edges={[
+      {
+        id: '1-2',
+        source: '1',
+        target: '2',
+        label:
+          'The Security Operations of the Cyber Defense System for the United States of America'
+      }
+    ]}
+  />
 );
 
 export const NodesOnly = () => (
@@ -45,29 +45,43 @@ export const Automatic = () => (
 
 export const SubLabels = () => (
   <GraphCanvas
-    nodes={[{
-      id: '1',
-      label: 'Node 1',
-      subLabel: 'SubLabel 1'
-    },
-    {
-      id: '2',
-      label: 'Node 2'
-    },
-    {
-      id: '3',
-      label: 'Node 3',
-      subLabel: 'SubLabel 3'
-    }]}
-    edges={[{
-      source: '1',
-      target: '2',
-      id: '1-2',
-    },
-    {
-      source: '3',
-      target: '1',
-      id: '3-1',
-    }]}
+    nodes={[
+      { id: '1', label: 'Node 1', subLabel: 'SubLabel 1' },
+      { id: '2', label: 'Node 2' },
+      { id: '3', label: 'Node 3', subLabel: 'SubLabel 3' }
+    ]}
+    edges={[
+      { source: '1', target: '2', id: '1-2' },
+      { source: '3', target: '1', id: '3-1' }
+    ]}
+  />
+);
+
+export const EdgeSubLabels = () => (
+  <GraphCanvas
+    labelType="edges"
+    nodes={[
+      { id: '1', label: 'Node 1' },
+      { id: '2', label: 'Node 2' },
+      { id: '3', label: 'Node 3' }
+    ]}
+    edges={[
+      {
+        source: '1',
+        target: '2',
+        id: '1-2',
+        label: 'Edge 1-2',
+        subLabel: 'Sub Label 1-2',
+        labelVisible: true
+      },
+      {
+        source: '1',
+        target: '3',
+        id: '1-3',
+        label: 'Edge 1-3',
+        subLabel: 'Sub Label 1-3',
+        labelVisible: true
+      }
+    ]}
   />
 );

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -236,10 +236,10 @@ export const Edge: FC<EdgeProps> = ({
     // Get angle of the edge
     const angle = Math.atan2(dy, dx);
 
-    // Calculate perpendicular angle
-    // Use PI/2 (90 degrees) for perpendicular direction
-    // Adding PI/2 instead of subtracting ensures the subLabel is placed below the main label
-    const perpAngle = angle + Math.PI / 2;
+    // Calculate perpendicular angle based on edge direction
+    // If dx is negative (edge going right to left), add PI/2 instead of subtracting
+    // This ensures the subLabel is always placed below the main label
+    const perpAngle = dx >= 0 ? angle - Math.PI / 2 : angle + Math.PI / 2;
 
     // Offset distance for subLabel
     const offsetDistance = 7;
@@ -255,7 +255,13 @@ export const Edge: FC<EdgeProps> = ({
     () => ({
       from: {
         labelPosition: center ? [center.x, center.y, center.z] : [0, 0, 0],
-        subLabelPosition: center ? [center.x, center.y, center.z] : [0, 0, 0]
+        subLabelPosition: center
+          ? [
+            center.x + subLabelOffset[0],
+            center.y + subLabelOffset[1],
+            center.z
+          ]
+          : [0, 0, 0]
       },
       to: {
         labelPosition: [midPoint.x, midPoint.y, midPoint.z],

--- a/src/themes/darkTheme.ts
+++ b/src/themes/darkTheme.ts
@@ -1,34 +1,18 @@
 import { Theme } from './theme';
 
 export const darkTheme: Theme = {
-  canvas: {
-    background: '#1E2026'
-  },
+  canvas: { background: '#1E2026' },
   node: {
     fill: '#7A8C9E',
     activeFill: '#1DE9AC',
     opacity: 1,
     selectedOpacity: 1,
     inactiveOpacity: 0.2,
-    label: {
-      stroke: '#1E2026',
-      color: '#ACBAC7',
-      activeColor: '#1DE9AC'
-    },
-    subLabel: {
-      stroke: '#1E2026',
-      color: '#ACBAC7',
-      activeColor: '#1DE9AC'
-    }
+    label: { stroke: '#1E2026', color: '#ACBAC7', activeColor: '#1DE9AC' },
+    subLabel: { stroke: '#1E2026', color: '#ACBAC7', activeColor: '#1DE9AC' }
   },
-  lasso: {
-    border: '1px solid #55aaff',
-    background: 'rgba(75, 160, 255, 0.1)'
-  },
-  ring: {
-    fill: '#54616D',
-    activeFill: '#1DE9AC'
-  },
+  lasso: { border: '1px solid #55aaff', background: 'rgba(75, 160, 255, 0.1)' },
+  ring: { fill: '#54616D', activeFill: '#1DE9AC' },
   edge: {
     fill: '#474B56',
     activeFill: '#1DE9AC',
@@ -40,20 +24,19 @@ export const darkTheme: Theme = {
       color: '#ACBAC7',
       activeColor: '#1DE9AC',
       fontSize: 6
+    },
+    subLabel: {
+      stroke: '#1E2026',
+      color: '#ACBAC7',
+      activeColor: '#1DE9AC'
     }
   },
-  arrow: {
-    fill: '#474B56',
-    activeFill: '#1DE9AC'
-  },
+  arrow: { fill: '#474B56', activeFill: '#1DE9AC' },
   cluster: {
     stroke: '#474B56',
     opacity: 1,
     selectedOpacity: 1,
     inactiveOpacity: 0.1,
-    label: {
-      stroke: '#1E2026',
-      color: '#ACBAC7'
-    }
+    label: { stroke: '#1E2026', color: '#ACBAC7' }
   }
 };

--- a/src/themes/lightTheme.ts
+++ b/src/themes/lightTheme.ts
@@ -1,34 +1,18 @@
 import { Theme } from './theme';
 
 export const lightTheme: Theme = {
-  canvas: {
-    background: '#fff'
-  },
+  canvas: { background: '#fff' },
   node: {
     fill: '#7CA0AB',
     activeFill: '#1DE9AC',
     opacity: 1,
     selectedOpacity: 1,
     inactiveOpacity: 0.2,
-    label: {
-      color: '#2A6475',
-      stroke: '#fff',
-      activeColor: '#1DE9AC'
-    },
-    subLabel: {
-      color: '#ddd',
-      stroke: 'transparent',
-      activeColor: '#1DE9AC'
-    }
+    label: { color: '#2A6475', stroke: '#fff', activeColor: '#1DE9AC' },
+    subLabel: { color: '#ddd', stroke: 'transparent', activeColor: '#1DE9AC' }
   },
-  lasso: {
-    border: '1px solid #55aaff',
-    background: 'rgba(75, 160, 255, 0.1)'
-  },
-  ring: {
-    fill: '#D8E6EA',
-    activeFill: '#1DE9AC'
-  },
+  lasso: { border: '1px solid #55aaff', background: 'rgba(75, 160, 255, 0.1)' },
+  ring: { fill: '#D8E6EA', activeFill: '#1DE9AC' },
   edge: {
     fill: '#D8E6EA',
     activeFill: '#1DE9AC',
@@ -40,20 +24,19 @@ export const lightTheme: Theme = {
       color: '#2A6475',
       activeColor: '#1DE9AC',
       fontSize: 6
+    },
+    subLabel: {
+      color: '#ddd',
+      stroke: 'transparent',
+      activeColor: '#1DE9AC'
     }
   },
-  arrow: {
-    fill: '#D8E6EA',
-    activeFill: '#1DE9AC'
-  },
+  arrow: { fill: '#D8E6EA', activeFill: '#1DE9AC' },
   cluster: {
     stroke: '#D8E6EA',
     opacity: 1,
     selectedOpacity: 1,
     inactiveOpacity: 0.1,
-    label: {
-      stroke: '#fff',
-      color: '#2A6475'
-    }
+    label: { stroke: '#fff', color: '#2A6475' }
   }
 };

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -22,10 +22,7 @@ export interface Theme {
       activeColor: ColorRepresentation;
     };
   };
-  ring: {
-    fill: ColorRepresentation;
-    activeFill: ColorRepresentation;
-  };
+  ring: { fill: ColorRepresentation; activeFill: ColorRepresentation };
   edge: {
     fill: ColorRepresentation;
     activeFill: ColorRepresentation;
@@ -38,15 +35,15 @@ export interface Theme {
       activeColor: ColorRepresentation;
       fontSize?: number;
     };
+    subLabel?: {
+      color: ColorRepresentation;
+      stroke?: ColorRepresentation;
+      activeColor: ColorRepresentation;
+      fontSize?: number;
+    };
   };
-  arrow: {
-    fill: ColorRepresentation;
-    activeFill: ColorRepresentation;
-  };
-  lasso: {
-    background: string;
-    border: string;
-  };
+  arrow: { fill: ColorRepresentation; activeFill: ColorRepresentation };
+  lasso: { background: string; border: string };
   cluster?: {
     stroke?: ColorRepresentation;
     fill?: ColorRepresentation;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,13 @@ export interface GraphEdge extends GraphElementBaseAttributes {
    * Target ID of the node.
    */
   target: string;
+
+  /**
+   * Placement of the subLabel relative to the main label.
+   * - 'below': Show subLabel below the main label (default)
+   * - 'above': Show subLabel above the main label
+   */
+  subLabelPlacement?: 'below' | 'above';
 }
 
 export interface Graph {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Edges didn't have a subLabel

Issue Number: #290


## What is the new behavior?
Now we have an optional prop to add a subLabel and display it under or over the Edge label
<img width="1427" alt="Screenshot 2025-06-19 at 2 58 32 PM" src="https://github.com/user-attachments/assets/dac79f6f-62ac-42f8-8bf7-b4093e5dc751" />


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
