### PR TITLE
Add Aggregate Edges Functionality

### DIFF
--- a/docs/demos/AggregateEdges.story.tsx
+++ b/docs/demos/AggregateEdges.story.tsx
@@ -1,0 +1,253 @@
+import React, { useState, useMemo } from 'react';
+import { GraphCanvas } from '../../src';
+
+export default {
+  title: 'Demos/AggregateEdges',
+  component: GraphCanvas
+};
+
+export const AggregateEdges = () => {
+  const [aggregateEdges, setAggregateEdges] = useState(true);
+
+  const edges = [
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-1',
+      label: 'Edge 1'
+    },
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-2',
+      label: 'Edge 2'
+    },
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-3',
+      label: 'Edge 3'
+    },
+    {
+      source: '2',
+      target: '1',
+      id: '2-1-1',
+      label: 'Edge 4'
+    },
+    {
+      source: '2',
+      target: '1',
+      id: '2-1-2',
+      label: 'Edge 5'
+    },
+    {
+      source: '2',
+      target: '1',
+      id: '2-1-3',
+      label: 'Edge 6'
+    }
+  ];
+
+  // Calculate how many visual edges would be displayed when aggregated
+  const aggregatedCount = useMemo(() => {
+    const sourceTargetPairs = new Set();
+    edges.forEach(edge => {
+      sourceTargetPairs.add(`${edge.source}-${edge.target}`);
+    });
+    return sourceTargetPairs.size;
+  }, [edges]);
+
+  return (
+    <div>
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          left: 10,
+          zIndex: 100,
+          background: 'rgba(255, 255, 255, 0.8)',
+          padding: '8px',
+          borderRadius: '4px'
+        }}
+      >
+        <div style={{ marginBottom: '8px' }}>
+          <strong>Edges:</strong>{' '}
+          {aggregateEdges ? aggregatedCount : edges.length}
+          {aggregateEdges && ` (aggregated from ${edges.length})`}
+        </div>
+        <button
+          onClick={() => setAggregateEdges(!aggregateEdges)}
+          style={{
+            padding: '6px 12px',
+            cursor: 'pointer',
+            background: '#4285f4',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontWeight: 'bold'
+          }}
+        >
+          {aggregateEdges ? 'Ungroup Edges' : 'Group Edges'}
+        </button>
+      </div>
+      <GraphCanvas
+        nodes={[
+          {
+            id: '1',
+            label: 'Node 1'
+          },
+          {
+            id: '2',
+            label: 'Node 2'
+          }
+        ]}
+        edges={edges}
+        aggregateEdges={aggregateEdges}
+      />
+    </div>
+  );
+};
+
+export const CompareWithoutAggregation = () => (
+  <GraphCanvas
+    nodes={[
+      {
+        id: '1',
+        label: 'Node 1'
+      },
+      {
+        id: '2',
+        label: 'Node 2'
+      }
+    ]}
+    edges={[
+      {
+        source: '1',
+        target: '2',
+        id: '1-2-1',
+        label: 'Edge 1'
+      },
+      {
+        source: '1',
+        target: '2',
+        id: '1-2-2',
+        label: 'Edge 2'
+      },
+      {
+        source: '1',
+        target: '2',
+        id: '1-2-3',
+        label: 'Edge 3'
+      },
+      {
+        source: '2',
+        target: '1',
+        id: '2-1-1',
+        label: 'Edge 4'
+      },
+      {
+        source: '2',
+        target: '1',
+        id: '2-1-2',
+        label: 'Edge 5'
+      },
+      {
+        source: '2',
+        target: '1',
+        id: '2-1-3',
+        label: 'Edge 6'
+      }
+    ]}
+    aggregateEdges={false}
+  />
+);
+
+export const ComplexExample = () => {
+  const [aggregateEdges, setAggregateEdges] = useState(true);
+
+  const edges = [
+    // Multiple edges between A and B
+    { id: 'A-B-1', source: 'A', target: 'B', label: 'A to B 1' },
+    { id: 'A-B-2', source: 'A', target: 'B', label: 'A to B 2' },
+    { id: 'A-B-3', source: 'A', target: 'B', label: 'A to B 3' },
+    { id: 'A-B-4', source: 'A', target: 'B', label: 'A to B 4' },
+
+    // Multiple edges between B and A (reverse direction)
+    { id: 'B-A-1', source: 'B', target: 'A', label: 'B to A 1' },
+    { id: 'B-A-2', source: 'B', target: 'A', label: 'B to A 2' },
+
+    // Multiple edges between B and C
+    { id: 'B-C-1', source: 'B', target: 'C', label: 'B to C 1' },
+    { id: 'B-C-2', source: 'B', target: 'C', label: 'B to C 2' },
+    { id: 'B-C-3', source: 'B', target: 'C', label: 'B to C 3' },
+
+    // Single edge between C and D
+    { id: 'C-D-1', source: 'C', target: 'D', label: 'C to D' },
+
+    // Multiple edges between D and E
+    { id: 'D-E-1', source: 'D', target: 'E', label: 'D to E 1' },
+    { id: 'D-E-2', source: 'D', target: 'E', label: 'D to E 2' },
+
+    // Multiple edges between E and A (completing the cycle)
+    { id: 'E-A-1', source: 'E', target: 'A', label: 'E to A 1' },
+    { id: 'E-A-2', source: 'E', target: 'A', label: 'E to A 2' },
+    { id: 'E-A-3', source: 'E', target: 'A', label: 'E to A 3' }
+  ];
+
+  // Calculate how many visual edges would be displayed when aggregated
+  const aggregatedCount = useMemo(() => {
+    const sourceTargetPairs = new Set();
+    edges.forEach(edge => {
+      sourceTargetPairs.add(`${edge.source}-${edge.target}`);
+    });
+    return sourceTargetPairs.size;
+  }, [edges]);
+
+  return (
+    <div>
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          left: 10,
+          zIndex: 100,
+          background: 'rgba(255, 255, 255, 0.8)',
+          padding: '8px',
+          borderRadius: '4px'
+        }}
+      >
+        <div style={{ marginBottom: '8px' }}>
+          <strong>Edges:</strong>{' '}
+          {aggregateEdges ? aggregatedCount : edges.length}
+          {aggregateEdges && ` (aggregated from ${edges.length})`}
+        </div>
+        <button
+          onClick={() => setAggregateEdges(!aggregateEdges)}
+          style={{
+            padding: '6px 12px',
+            cursor: 'pointer',
+            background: '#4285f4',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontWeight: 'bold'
+          }}
+        >
+          {aggregateEdges ? 'Ungroup Edges' : 'Group Edges'}
+        </button>
+      </div>
+      <GraphCanvas
+        nodes={[
+          { id: 'A', label: 'Node A' },
+          { id: 'B', label: 'Node B' },
+          { id: 'C', label: 'Node C' },
+          { id: 'D', label: 'Node D' },
+          { id: 'E', label: 'Node E' }
+        ]}
+        edges={edges}
+        aggregateEdges={aggregateEdges}
+        layoutType="forceDirected2d"
+      />
+    </div>
+  );
+};

--- a/docs/demos/AggregateEdges.story.tsx
+++ b/docs/demos/AggregateEdges.story.tsx
@@ -103,6 +103,11 @@ export const AggregateEdges = () => {
         ]}
         edges={edges}
         aggregateEdges={aggregateEdges}
+        layoutType="forceDirected2d"
+        layoutOverrides={{
+          linkDistance: 200,
+          nodeStrength: -1000
+        }}
       />
     </div>
   );
@@ -247,6 +252,10 @@ export const ComplexExample = () => {
         edges={edges}
         aggregateEdges={aggregateEdges}
         layoutType="forceDirected2d"
+        layoutOverrides={{
+          linkDistance: 300,
+          nodeStrength: -2000
+        }}
       />
     </div>
   );

--- a/docs/demos/AggregateEdges.story.tsx
+++ b/docs/demos/AggregateEdges.story.tsx
@@ -278,6 +278,7 @@ export const ComplexExample = () => {
         edges={edges}
         aggregateEdges={aggregateEdges}
         layoutType="forceDirected2d"
+        labelType="all"
         layoutOverrides={{
           linkDistance: 300,
           nodeStrength: -2000

--- a/docs/demos/AggregateEdges.story.tsx
+++ b/docs/demos/AggregateEdges.story.tsx
@@ -6,45 +6,39 @@ export default {
   component: GraphCanvas
 };
 
-export const AggregateEdges = () => {
-  const [aggregateEdges, setAggregateEdges] = useState(true);
+export const AggregateEdgesSimple = () => {
+  const [aggregateEdges, setAggregateEdges] = useState(false);
 
   const edges = [
     {
       source: '1',
       target: '2',
-      id: '1-2-1',
-      label: 'Edge 1'
+      id: '1-2-1'
     },
     {
       source: '1',
       target: '2',
-      id: '1-2-2',
-      label: 'Edge 2'
+      id: '1-2-2'
     },
     {
       source: '1',
       target: '2',
-      id: '1-2-3',
-      label: 'Edge 3'
+      id: '1-2-3'
     },
     {
       source: '2',
       target: '1',
-      id: '2-1-1',
-      label: 'Edge 4'
+      id: '2-1-1'
     },
     {
       source: '2',
       target: '1',
-      id: '2-1-2',
-      label: 'Edge 5'
+      id: '2-1-2'
     },
     {
       source: '2',
       target: '1',
-      id: '2-1-3',
-      label: 'Edge 6'
+      id: '2-1-3'
     }
   ];
 
@@ -113,62 +107,94 @@ export const AggregateEdges = () => {
   );
 };
 
-export const CompareWithoutAggregation = () => (
-  <GraphCanvas
-    nodes={[
-      {
-        id: '1',
-        label: 'Node 1'
-      },
-      {
-        id: '2',
-        label: 'Node 2'
-      }
-    ]}
-    edges={[
-      {
-        source: '1',
-        target: '2',
-        id: '1-2-1',
-        label: 'Edge 1'
-      },
-      {
-        source: '1',
-        target: '2',
-        id: '1-2-2',
-        label: 'Edge 2'
-      },
-      {
-        source: '1',
-        target: '2',
-        id: '1-2-3',
-        label: 'Edge 3'
-      },
-      {
-        source: '2',
-        target: '1',
-        id: '2-1-1',
-        label: 'Edge 4'
-      },
-      {
-        source: '2',
-        target: '1',
-        id: '2-1-2',
-        label: 'Edge 5'
-      },
-      {
-        source: '2',
-        target: '1',
-        id: '2-1-3',
-        label: 'Edge 6'
-      }
-    ]}
-    aggregateEdges={false}
-  />
-);
+export const AggregateEdgesOneDirection = () => {
+  const [aggregateEdges, setAggregateEdges] = useState(false);
+
+  const edges = [
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-1'
+    },
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-2'
+    },
+    {
+      source: '1',
+      target: '2',
+      id: '1-2-3'
+    }
+  ];
+
+  // Calculate how many visual edges would be displayed when aggregated
+  const aggregatedCount = useMemo(() => {
+    const sourceTargetPairs = new Set();
+    edges.forEach(edge => {
+      sourceTargetPairs.add(`${edge.source}-${edge.target}`);
+    });
+    return sourceTargetPairs.size;
+  }, [edges]);
+
+  return (
+    <div>
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          left: 10,
+          zIndex: 100,
+          background: 'rgba(255, 255, 255, 0.8)',
+          padding: '8px',
+          borderRadius: '4px'
+        }}
+      >
+        <div style={{ marginBottom: '8px' }}>
+          <strong>Edges:</strong>{' '}
+          {aggregateEdges ? aggregatedCount : edges.length}
+          {aggregateEdges && ` (aggregated from ${edges.length})`}
+        </div>
+        <button
+          onClick={() => setAggregateEdges(!aggregateEdges)}
+          style={{
+            padding: '6px 12px',
+            cursor: 'pointer',
+            background: '#4285f4',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontWeight: 'bold'
+          }}
+        >
+          {aggregateEdges ? 'Ungroup Edges' : 'Group Edges'}
+        </button>
+      </div>
+      <GraphCanvas
+        nodes={[
+          {
+            id: '1',
+            label: 'Node 1'
+          },
+          {
+            id: '2',
+            label: 'Node 2'
+          }
+        ]}
+        edges={edges}
+        aggregateEdges={aggregateEdges}
+        layoutType="forceDirected2d"
+        layoutOverrides={{
+          linkDistance: 200,
+          nodeStrength: -1000
+        }}
+      />
+    </div>
+  );
+};
 
 export const ComplexExample = () => {
-  const [aggregateEdges, setAggregateEdges] = useState(true);
+  const [aggregateEdges, setAggregateEdges] = useState(false);
 
   const edges = [
     // Multiple edges between A and B

--- a/src/GraphCanvas/GraphCanvas.tsx
+++ b/src/GraphCanvas/GraphCanvas.tsx
@@ -71,6 +71,11 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
    * When the canvas was clicked but didn't hit a node/edge.
    */
   onCanvasClick?: (event: MouseEvent) => void;
+
+  /**
+   * Whether to aggregate edges with the same source and target.
+   */
+  aggregateEdges?: boolean;
 }
 
 export type GraphCanvasRef = Omit<GraphSceneRef, 'graph' | 'renderScene'> &
@@ -128,6 +133,7 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
         disabled,
         onLasso,
         onLassoEnd,
+        aggregateEdges,
         ...rest
       },
       ref: Ref<GraphCanvasRef>
@@ -228,6 +234,7 @@ export const GraphCanvas: FC<GraphCanvasProps & { ref?: Ref<GraphCanvasRef> }> =
                       defaultNodeSize={defaultNodeSize}
                       minNodeSize={minNodeSize}
                       maxNodeSize={maxNodeSize}
+                      aggregateEdges={aggregateEdges}
                       {...rest}
                     />
                   </Suspense>

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -357,7 +357,7 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       },
       ref
     ) => {
-      const { layoutType, clusterAttribute } = rest;
+      const { layoutType, clusterAttribute, labelType } = rest;
 
       // Get the gl/scene/camera for render shortcuts
       const gl = useThree(state => state.gl);
@@ -386,12 +386,12 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       // Process edges based on aggregation setting and update store
       const edges = useMemo(() => {
         if (aggregateEdges) {
-          const aggregatedEdges = aggregateEdgesUtil(graph);
+          const aggregatedEdges = aggregateEdgesUtil(graph, labelType);
           return aggregatedEdges;
         } else {
           return edgesStore;
         }
-      }, [edgesStore, aggregateEdges, graph]);
+      }, [edgesStore, aggregateEdges, graph, labelType]);
 
       // Update the store if edges were aggregated (moved to useEffect to avoid render cycle error)
       useEffect(() => {

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -386,19 +386,19 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       // Process edges based on aggregation setting and update store
       const edges = useMemo(() => {
         if (aggregateEdges) {
-          const aggregatedEdges = aggregateEdgesUtil(edgesStore);
+          const aggregatedEdges = aggregateEdgesUtil(graph);
           return aggregatedEdges;
         } else {
           return edgesStore;
         }
-      }, [edgesStore, aggregateEdges]);
+      }, [edgesStore, aggregateEdges, graph]);
 
       // Update the store if edges were aggregated (moved to useEffect to avoid render cycle error)
       useEffect(() => {
-        if (edgesStore.length !== edges.length) {
+        if (aggregateEdges && edgesStore.length !== edges.length) {
           setEdges(edges);
         }
-      }, [edges, edgesStore.length, setEdges]);
+      }, [edges, edgesStore.length, setEdges, aggregateEdges]);
 
       // Center the graph on the nodes
       const { centerNodesById, fitNodesInViewById, isCentered } =

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -6,7 +6,8 @@ import React, {
   Ref,
   useCallback,
   useImperativeHandle,
-  useMemo
+  useMemo,
+  useEffect
 } from 'react';
 import { useGraph } from './useGraph';
 import { LayoutOverrides, LayoutTypes } from './layout';
@@ -392,10 +393,12 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
         }
       }, [edgesStore, aggregateEdges]);
 
-      // Update the store if edges were aggregated
-      if (edgesStore.length !== edges.length) {
-        setEdges(edges);
-      }
+      // Update the store if edges were aggregated (moved to useEffect to avoid render cycle error)
+      useEffect(() => {
+        if (edgesStore.length !== edges.length) {
+          setEdges(edges);
+        }
+      }, [edges, edgesStore.length, setEdges]);
 
       // Center the graph on the nodes
       const { centerNodesById, fitNodesInViewById, isCentered } =

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -382,13 +382,10 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       const clusters = useStore(state => [...state.clusters.values()]);
 
       // Process edges based on aggregation setting
-      const edges = useMemo(() => {
-        const processedEdges = aggregateEdges
-          ? aggregateEdgesUtil(edgesStore)
-          : edgesStore;
-        // Filter out any undefined edges
-        return processedEdges.filter(edge => edge !== undefined);
-      }, [edgesStore, aggregateEdges]);
+      const edges = useMemo(
+        () => (aggregateEdges ? aggregateEdgesUtil(edgesStore) : edgesStore),
+        [edgesStore, aggregateEdges]
+      );
 
       // Center the graph on the nodes
       const { centerNodesById, fitNodesInViewById, isCentered } =

--- a/src/GraphScene.tsx
+++ b/src/GraphScene.tsx
@@ -379,13 +379,23 @@ export const GraphScene: FC<GraphSceneProps & { ref?: Ref<GraphSceneRef> }> =
       const graph = useStore(state => state.graph);
       const nodes = useStore(state => state.nodes);
       const edgesStore = useStore(state => state.edges);
+      const setEdges = useStore(state => state.setEdges);
       const clusters = useStore(state => [...state.clusters.values()]);
 
-      // Process edges based on aggregation setting
-      const edges = useMemo(
-        () => (aggregateEdges ? aggregateEdgesUtil(edgesStore) : edgesStore),
-        [edgesStore, aggregateEdges]
-      );
+      // Process edges based on aggregation setting and update store
+      const edges = useMemo(() => {
+        if (aggregateEdges) {
+          const aggregatedEdges = aggregateEdgesUtil(edgesStore);
+          return aggregatedEdges;
+        } else {
+          return edgesStore;
+        }
+      }, [edgesStore, aggregateEdges]);
+
+      // Update the store if edges were aggregated
+      if (edgesStore.length !== edges.length) {
+        setEdges(edges);
+      }
 
       // Center the graph on the nodes
       const { centerNodesById, fitNodesInViewById, isCentered } =

--- a/src/symbols/Label.tsx
+++ b/src/symbols/Label.tsx
@@ -70,7 +70,7 @@ export const Label: FC<LabelProps> = ({
   );
 
   return (
-    <Billboard position={[0, 0, 1]}>
+    <Billboard position={[0, 0, 1]} renderOrder={1}>
       <Text
         font={fontUrl}
         fontSize={fontSize}

--- a/src/symbols/Line.tsx
+++ b/src/symbols/Line.tsx
@@ -145,6 +145,7 @@ export const Line: FC<LineProps> = ({
   return (
     <mesh
       userData={{ id, type: 'edge' }}
+      renderOrder={-1}
       onPointerOver={onPointerOver}
       onPointerOut={onPointerOut}
       onClick={onClick}

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -63,8 +63,6 @@ export const aggregateEdges = (
         target,
         label: `${group.length} edges`,
         labelVisible: true,
-        // Increase the size based on the number of edges in the group
-        // size: Math.min(5, 1 + Math.log(group.length)),
         // Store the original edges in the data property
         data: {
           ...(firstEdge.data || {}),

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -1,0 +1,81 @@
+import { InternalGraphEdge } from '../types';
+
+/**
+ * Groups edges by their source and target nodes.
+ * @param edges Array of edges to group
+ * @returns Map with source-target pairs as keys and arrays of edges as values
+ */
+export const groupEdgesBySourceTarget = (
+  edges: InternalGraphEdge[]
+): Map<string, InternalGraphEdge[]> => {
+  const edgeGroups = new Map<string, InternalGraphEdge[]>();
+
+  // Filter out undefined edges
+  const validEdges = edges.filter(edge => edge && edge.source && edge.target);
+
+  validEdges.forEach(edge => {
+    // Create a key that represents the source-target pair
+    // We sort the source and target to ensure that edges in both directions are grouped separately
+    const key = `${edge.source}-${edge.target}`;
+
+    if (!edgeGroups.has(key)) {
+      edgeGroups.set(key, []);
+    }
+
+    edgeGroups.get(key)!.push(edge);
+  });
+
+  return edgeGroups;
+};
+
+/**
+ * Aggregates edges with the same source and target.
+ * @param edges Array of edges to aggregate
+ * @returns Array of aggregated edges
+ */
+export const aggregateEdges = (
+  edges: InternalGraphEdge[]
+): InternalGraphEdge[] => {
+  if (!edges || edges.length === 0) {
+    return [];
+  }
+
+  const edgeGroups = groupEdgesBySourceTarget(edges);
+  const aggregatedEdges: InternalGraphEdge[] = [];
+
+  edgeGroups.forEach((group, key) => {
+    if (group.length === 1) {
+      // If there's only one edge in the group, just add it as is
+      aggregatedEdges.push(group[0]);
+    } else {
+      // If there are multiple edges, create an aggregated edge
+      const [source, target] = key.split('-');
+      const firstEdge = group[0];
+
+      if (!source || !target || !firstEdge) {
+        return; // Skip this group if we don't have valid source/target
+      }
+
+      // Create an aggregated edge that represents the group
+      const aggregatedEdge: InternalGraphEdge = {
+        ...firstEdge,
+        source,
+        target,
+        label: `${group.length} edges`,
+        labelVisible: true,
+        // Increase the size based on the number of edges in the group
+        // size: Math.min(5, 1 + Math.log(group.length)),
+        // Store the original edges in the data property
+        data: {
+          ...(firstEdge.data || {}),
+          originalEdges: group,
+          count: group.length
+        }
+      };
+
+      aggregatedEdges.push(aggregatedEdge);
+    }
+  });
+
+  return aggregatedEdges;
+};

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -44,9 +44,20 @@ export const aggregateEdges = (
   const aggregatedEdges: InternalGraphEdge[] = [];
 
   edgeGroups.forEach((group, key) => {
-    if (group.length === 1) {
-      // If there's only one edge in the group, just add it as is
-      aggregatedEdges.push(group[0]);
+    if (edgeGroups.size === 1) {
+      // If there's only one edge in the group, mark it as aggregated with 1 original edge
+      const singleEdge = group[0];
+      const aggregatedEdge: InternalGraphEdge = {
+        ...singleEdge,
+        // Store the original edge in the data property to mark it as having gone through aggregation
+        data: {
+          ...(singleEdge.data || {}),
+          originalEdges: group,
+          count: 1,
+          isAggregated: true
+        }
+      };
+      aggregatedEdges.push(aggregatedEdge);
     } else {
       // If there are multiple edges, create an aggregated edge
       const [source, target] = key.split('-');
@@ -67,7 +78,8 @@ export const aggregateEdges = (
         data: {
           ...(firstEdge.data || {}),
           originalEdges: group,
-          count: group.length
+          count: group.length,
+          isAggregated: true
         }
       };
 

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -44,47 +44,31 @@ export const aggregateEdges = (
   const aggregatedEdges: InternalGraphEdge[] = [];
 
   edgeGroups.forEach((group, key) => {
-    if (edgeGroups.size === 1) {
-      // If there's only one edge in the group, mark it as aggregated with 1 original edge
-      const singleEdge = group[0];
-      const aggregatedEdge: InternalGraphEdge = {
-        ...singleEdge,
-        // Store the original edge in the data property to mark it as having gone through aggregation
-        data: {
-          ...(singleEdge.data || {}),
-          originalEdges: group,
-          count: 1,
-          isAggregated: true
-        }
-      };
-      aggregatedEdges.push(aggregatedEdge);
-    } else {
-      // If there are multiple edges, create an aggregated edge
-      const [source, target] = key.split('-');
-      const firstEdge = group[0];
+    // If there are multiple edges, create an aggregated edge
+    const [source, target] = key.split('-');
+    const firstEdge = group[0];
 
-      if (!source || !target || !firstEdge) {
-        return; // Skip this group if we don't have valid source/target
-      }
-
-      // Create an aggregated edge that represents the group
-      const aggregatedEdge: InternalGraphEdge = {
-        ...firstEdge,
-        source,
-        target,
-        label: `${group.length} edges`,
-        labelVisible: true,
-        // Store the original edges in the data property
-        data: {
-          ...(firstEdge.data || {}),
-          originalEdges: group,
-          count: group.length,
-          isAggregated: true
-        }
-      };
-
-      aggregatedEdges.push(aggregatedEdge);
+    if (!source || !target || !firstEdge) {
+      return; // Skip this group if we don't have valid source/target
     }
+
+    // Create an aggregated edge that represents the group
+    const aggregatedEdge: InternalGraphEdge = {
+      ...firstEdge,
+      source,
+      target,
+      label: `${group.length} edges`,
+      labelVisible: true,
+      // Store the original edges in the data property
+      data: {
+        ...(firstEdge.data || {}),
+        originalEdges: group,
+        count: group.length,
+        isAggregated: true
+      }
+    };
+
+    aggregatedEdges.push(aggregatedEdge);
   });
 
   return aggregatedEdges;

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -1,5 +1,6 @@
 import { InternalGraphEdge } from '../types';
 import Graph from 'graphology';
+import { LabelVisibilityType } from './visibility';
 
 /**
  * Graphology-native approach using reduceEdges for optimal performance
@@ -44,9 +45,13 @@ export const groupEdgesBySourceTarget = (
 /**
  * Aggregates edges with the same source and target using Graphology's native functions
  * @param graph Graphology graph instance
+ * @param labelType Label visibility type to determine if edge labels should be visible
  * @returns Array of aggregated edges
  */
-export const aggregateEdges = (graph: Graph): InternalGraphEdge[] => {
+export const aggregateEdges = (
+  graph: Graph,
+  labelType?: LabelVisibilityType
+): InternalGraphEdge[] => {
   if (!graph || graph.size === 0) {
     return [];
   }
@@ -54,6 +59,8 @@ export const aggregateEdges = (graph: Graph): InternalGraphEdge[] => {
   // Use Graphology's native reduceEdges to group and aggregate in one pass
   const edgeGroups = groupEdgesBySourceTarget(graph);
   const aggregatedEdges: InternalGraphEdge[] = [];
+  // Determine if edge labels should be visible based on labelType
+  const shouldShowEdgeLabels = labelType === 'all' || labelType === 'edges';
 
   // Process groups efficiently
   for (const [key, group] of edgeGroups) {
@@ -70,7 +77,7 @@ export const aggregateEdges = (graph: Graph): InternalGraphEdge[] => {
       source,
       target,
       label: `${group.length} edges`,
-      labelVisible: true,
+      labelVisible: shouldShowEdgeLabels,
       // Store the original edges in the data property
       data: {
         ...(firstEdge.data || {}),

--- a/src/utils/aggregateEdges.ts
+++ b/src/utils/aggregateEdges.ts
@@ -71,6 +71,10 @@ export const aggregateEdges = (
       continue;
     }
 
+    // Calculate the aggregated edge size based on the number of edges
+    const baseSize = firstEdge.size || 1; // Default to 1 if no size is specified
+    const aggregatedSize = baseSize + group.length * baseSize * 0.5;
+
     // Create an aggregated edge that represents the group
     const aggregatedEdge: InternalGraphEdge = {
       ...firstEdge,
@@ -78,12 +82,14 @@ export const aggregateEdges = (
       target,
       label: `${group.length} edges`,
       labelVisible: shouldShowEdgeLabels,
+      size: aggregatedSize,
       // Store the original edges in the data property
       data: {
         ...(firstEdge.data || {}),
         originalEdges: group,
         count: group.length,
-        isAggregated: true
+        isAggregated: true,
+        originalSize: baseSize
       }
     };
 

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -121,18 +121,21 @@ export function calculateEdgeCurveOffset({ edge, edges, curved }) {
     updatedCurved = true;
     const edgeIndex = parallelEdges.indexOf(edge.id);
 
-    if (parallelEdges.length === 2) {
-      // Keep the simple case for 2 edges
-      curveOffset =
-        edgeIndex === 0 ? MULTI_EDGE_OFFSET_FACTOR : -MULTI_EDGE_OFFSET_FACTOR;
-    } else {
-      // Progressive distribution with unique magnitude for each edge
-      // This prevents overlapping by ensuring each edge has sufficient separation
-      const offsetMultiplier = edgeIndex === 0 ? 1 : 1 + edgeIndex * 0.8;
-      const side = edgeIndex % 2 === 0 ? 1 : -1;
-      const magnitude = MULTI_EDGE_OFFSET_FACTOR * offsetMultiplier;
-      curveOffset = side * magnitude;
-    }
+    // Progressive distribution with unique magnitude for each edge
+    // This prevents overlapping by ensuring each edge has sufficient separation
+    const offsetMultiplier = edgeIndex === 0 ? 1 : 1 + edgeIndex * 0.8;
+    const side = edgeIndex % 2 === 0 ? 1 : -1;
+    const magnitude = MULTI_EDGE_OFFSET_FACTOR * offsetMultiplier;
+    curveOffset = side * magnitude;
+  }
+
+  if (edge.data?.isAggregated && edges.length > 1) {
+    const edgeIndex = parallelEdges.indexOf(edge.id);
+    return {
+      curved: true,
+      curveOffset:
+        edgeIndex === 0 ? MULTI_EDGE_OFFSET_FACTOR : -MULTI_EDGE_OFFSET_FACTOR
+    };
   }
 
   return { curved: updatedCurved, curveOffset };

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -122,12 +122,16 @@ export function calculateEdgeCurveOffset({ edge, edges, curved }) {
     const edgeIndex = parallelEdges.indexOf(edge.id);
 
     if (parallelEdges.length === 2) {
+      // Keep the simple case for 2 edges
       curveOffset =
         edgeIndex === 0 ? MULTI_EDGE_OFFSET_FACTOR : -MULTI_EDGE_OFFSET_FACTOR;
     } else {
-      curveOffset =
-        (edgeIndex - Math.floor(parallelEdges.length / 2)) *
-        MULTI_EDGE_OFFSET_FACTOR;
+      // Progressive distribution with unique magnitude for each edge
+      // This prevents overlapping by ensuring each edge has sufficient separation
+      const offsetMultiplier = edgeIndex === 0 ? 1 : 1 + edgeIndex * 0.8;
+      const side = edgeIndex % 2 === 0 ? 1 : -1;
+      const magnitude = MULTI_EDGE_OFFSET_FACTOR * offsetMultiplier;
+      curveOffset = side * magnitude;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Previously, edges used to stack on top of each other when there were more than three edges between two nodes.

## What is the new behavior?

Now, we can pass an optional `aggregateEdges` prop to aggregate edges that connect the same pair of nodes in both directions.

https://github.com/user-attachments/assets/daa23e30-6cf0-4d77-ad17-79e831e8c0dc

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
