### PR TITLE
fix: prevent default browser context menu from appearing on edge righ…

### DIFF
--- a/src/symbols/Arrow.tsx
+++ b/src/symbols/Arrow.tsx
@@ -101,13 +101,16 @@ export const Arrow: FC<ArrowProps> = ({
       scale={[1, 1, 1]}
       onPointerOver={() => onActive(true)}
       onPointerOut={() => onActive(false)}
+      // context menu controls
       onPointerDown={event => {
-        // context menu controls
         if (event.nativeEvent.buttons === 2) {
-          event.nativeEvent.preventDefault();
           event.stopPropagation();
-          onContextMenu();
         }
+      }}
+      onContextMenu={event => {
+        event.nativeEvent.preventDefault();
+        event.stopPropagation();
+        onContextMenu();
       }}
     >
       <cylinderGeometry

--- a/src/symbols/Line.tsx
+++ b/src/symbols/Line.tsx
@@ -100,15 +100,15 @@ const dashedFragmentShader = `
   uniform float gapSize;
   uniform float lineLength;
   varying vec2 vUv;
-  
+
   void main() {
     float totalSize = dashSize + gapSize;
     float position = mod(vUv.x * lineLength, totalSize);
-    
+
     if (position > dashSize) {
       discard;
     }
-    
+
     gl_FragColor = vec4(color, opacity);
   }
 `;
@@ -216,13 +216,16 @@ export const Line: FC<LineProps> = ({
       onPointerOver={onPointerOver}
       onPointerOut={onPointerOut}
       onClick={onClick}
+      // context menu controls
       onPointerDown={event => {
-        // context menu controls
         if (event.nativeEvent.buttons === 2) {
-          event.nativeEvent.preventDefault();
           event.stopPropagation();
-          onContextMenu();
         }
+      }}
+      onContextMenu={event => {
+        event.nativeEvent.preventDefault();
+        event.stopPropagation();
+        onContextMenu();
       }}
     >
       <tubeGeometry attach="geometry" ref={tubeRef} />


### PR DESCRIPTION
…t-click

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When right-clicking on an edge, the custom context menu appears but the default browser context menu also shows up, causing UI overlap and unintended behavior.

Issue Number: 346


## What is the new behavior?
Right-clicking on an edge now only opens the custom context menu.
The default browser context menu is suppressed using preventDefault() in the onContextMenu handler, and event propagation is stopped to prevent interference from other scene elements.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

onPointerDown fires before contextmenu, but the browser doesn’t care unless you also stop the contextmenu event.
onContextMenu directly intercepts the event that causes the browser menu.
event.preventDefault() removes the default menu, and event.stopPropagation() keeps it from triggering higher-level handlers.
