### PR TITLE
Fix edge label rotation when animated=false

### DIFF
--- a/src/symbols/edges/Edge.tsx
+++ b/src/symbols/edges/Edge.tsx
@@ -137,25 +137,26 @@ export const Edge: FC<EdgeProps> = ({
     [edgeContextMenus, setEdgeContextMenus]
   );
 
-  const labelRotation = useMemo(() => {
-    if (labelPlacement === 'natural') {
-      return new Euler(0, 0, 0);
-    }
-    return new Euler(
-      0,
-      0,
-      Math.atan2(
-        to.position.y - from.position.y,
-        to.position.x - from.position.x
-      )
-    );
-  }, [
-    labelPlacement,
-    to.position.y,
-    to.position.x,
-    from.position.y,
-    from.position.x
-  ]);
+  const labelRotation = useMemo(
+    () =>
+      new Euler(
+        0,
+        0,
+        labelPlacement === 'natural'
+          ? 0
+          : Math.atan(
+            (to.position.y - from.position.y) /
+                (to.position.x - from.position.x)
+          )
+      ),
+    [
+      to.position.x,
+      to.position.y,
+      from.position.x,
+      from.position.y,
+      labelPlacement
+    ]
+  );
 
   const htmlProps = useMemo(
     () => ({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Edge label rotation is wrong when animated=false

Issue Number: N/A


## What is the new behavior?
Edge label rotation is correct when animated=false

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Before
<img width="484" height="164" alt="image" src="https://github.com/user-attachments/assets/f9bf7556-15f3-4d08-a095-d6056e20847e" />

After
<img width="212" height="93" alt="Screenshot 2025-08-27 at 14 33 50" src="https://github.com/user-attachments/assets/262d5c18-9677-451f-bd82-fa19cefdbe30" />
