### PR TITLE
Cosmos.gl renderer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Reagraph is a high-performance network graph visualization built in WebGL for Re
 
 ## ✨ Features
 - WebGL based for high performance
+- Optional cosmos.gl renderer for large 2D graphs
 - Node Sizing based on attribute, page rank, centrality, custom
 - Light and Dark Mode with custom theme ability
 - Path finding between nodes
@@ -123,6 +124,37 @@ export default () => (
 ```
 
 Checkout an example on [CodeSandbox](https://codesandbox.io/s/reagraph-example-mwh96q).
+
+### Optional cosmos.gl renderer
+
+Three.js is the default renderer. For very large 2D graphs, opt into the
+cosmos.gl renderer with `renderEngine="cosmos"`:
+
+```tsx
+import React, { useRef } from 'react';
+import { GraphCanvas, type CosmosGraphCanvasRef } from 'reagraph';
+
+export default ({ nodes, edges }) => {
+  const graphRef = useRef<CosmosGraphCanvasRef | null>(null);
+
+  return (
+    <GraphCanvas
+      ref={graphRef}
+      renderEngine="cosmos"
+      nodes={nodes}
+      edges={edges}
+      cosmosConfig={{ labelMaxCount: 50 }}
+    />
+  );
+};
+```
+
+`GraphCanvasRef` remains the default Three.js ref type. Use
+`CosmosGraphCanvasRef` when `renderEngine="cosmos"`. The cosmos renderer
+supports Reagraph styling, labels, node/edge click and hover, node double click,
+node/edge context menu, and node drag-end callbacks. Three.js-only features such
+as lasso selection, custom renderers, children, and cluster rendering/events are
+not supported by the cosmos renderer.
 
 ## 🔭 Development
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ Reagraph is a high-performance network graph visualization built in WebGL for Re
 
 - [Reaflow](https://reaflow.dev?utm=reagraph) - Open-source library for workflow and diagram graphs.
 - [Reablocks](https://reablocks.dev?utm=reagraph) - Open-source component library for React based on Tailwind.
-- [Reaviz](https://reaviz.dev?utm=reagraph) - Open-source library for data visualizations for React. 
+- [Reaviz](https://reaviz.dev?utm=reagraph) - Open-source library for data visualizations for React.
 - [Reachat](https://reachat.dev?utm=reagraph) - Open-source library for building LLM/Chat UIs for React.
 
 ## ✨ Features
+
 - WebGL based for high performance
 - Optional cosmos.gl renderer for large 2D graphs
 - Node Sizing based on attribute, page rank, centrality, custom
@@ -150,11 +151,13 @@ export default ({ nodes, edges }) => {
 ```
 
 `GraphCanvasRef` remains the default Three.js ref type. Use
-`CosmosGraphCanvasRef` when `renderEngine="cosmos"`. The cosmos renderer
-supports Reagraph styling, labels, node/edge click and hover, node double click,
-node/edge context menu, and node drag-end callbacks. Three.js-only features such
-as lasso selection, custom renderers, children, and cluster rendering/events are
-not supported by the cosmos renderer.
+`CosmosGraphCanvasRef` when `renderEngine="cosmos"`. The cosmos ref exposes
+`getControls()` with a cosmos-specific controls adapter plus `getCosmosGraph()`
+for advanced access. The cosmos renderer supports Reagraph styling, labels,
+node/edge click and hover, node double click, node/edge context menu, node
+drag-end callbacks, and node lasso selection. Three.js-only features such as
+edge lasso selection, custom renderers, children, and cluster rendering/events
+are not supported by the cosmos renderer.
 
 ## 🔭 Development
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,15 @@
+# Third-Party Notices
+
+This project depends on third-party open source software. Reagraph itself is
+licensed under the Apache License 2.0; third-party dependencies remain under
+their respective licenses.
+
+## @cosmos.gl/graph
+
+- Package: `@cosmos.gl/graph`
+- Version: `2.6.4`
+- License: MIT
+- Project: https://github.com/cosmosgl/graph
+
+`@cosmos.gl/graph` is used by Reagraph's optional `renderEngine="cosmos"`
+renderer for large 2D graphs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "reagraph",
-  "version": "4.30.7",
+  "version": "4.30.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reagraph",
-      "version": "4.30.7",
+      "version": "4.30.8",
       "license": "Apache-2.0",
       "dependencies": {
+        "@cosmos.gl/graph": "^2.6.4",
         "@react-spring/three": "10.0.3",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
@@ -1895,6 +1896,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@cosmos.gl/graph": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@cosmos.gl/graph/-/graph-2.6.4.tgz",
+      "integrity": "sha512-i+N9lSpAjGLTUPelo/bKNbQnKPDqt3k2UnRlfIWe2Lrambc4J3QFgOfpR8AalQ/1tgLRoeNtVBZ1GPpsNqae5w==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^3.2.0",
+        "d3-color": "^3.1.0",
+        "d3-drag": "^3.0.0",
+        "d3-ease": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1",
+        "d3-zoom": "^3.0.0",
+        "dompurify": "^3.2.6",
+        "gl-bench": "^1.0.42",
+        "gl-matrix": "^3.4.3",
+        "random": "^4.1.0",
+        "regl": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.2.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
@@ -5546,6 +5572,13 @@
         "meshoptimizer": "~0.22.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
@@ -7302,6 +7335,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-force-3d": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
@@ -7379,6 +7434,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-time": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
@@ -7408,6 +7472,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -7614,6 +7713,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -9040,6 +9148,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gl-bench": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/gl-bench/-/gl-bench-1.0.42.tgz",
+      "integrity": "sha512-zuMsA/NCPmI8dPy6q3zTUH8OUM5cqKg7uVWwqzrtXJPBqoypM0XeFWEc8iFOqbf/1qtXieWOrbmgFEByKTQt4Q==",
+      "license": "MIT"
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -12336,6 +12456,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/random": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/random/-/random-4.1.0.tgz",
+      "integrity": "sha512-6Ajb7XmMSE9EFAMGC3kg9mvE7fGlBip25mYYuSMzw/uUSrmGilvZo2qwX3RnTRjwXkwkS+4swse9otZ92VjAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -12641,6 +12773,12 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/regl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
+      "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12868,6 +13006,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "homepage": "https://github.com/reaviz/reagraph#readme",
   "dependencies": {
+    "@cosmos.gl/graph": "^2.6.4",
     "@react-spring/three": "10.0.3",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",

--- a/src/GraphCanvas/CosmosGraphCanvas.tsx
+++ b/src/GraphCanvas/CosmosGraphCanvas.tsx
@@ -12,6 +12,7 @@ import React, {
   useState
 } from 'react';
 
+import { createElement } from '../selection/utils';
 import { lightTheme } from '../themes';
 import type { InternalGraphEdge, InternalGraphNode } from '../types';
 import type { PreparedCosmosGraph } from './cosmos';
@@ -26,7 +27,11 @@ import {
   DEFAULT_COSMOS_LABEL_MAX_COUNT,
   DEFAULT_COSMOS_LABEL_UPDATE_INTERVAL
 } from './CosmosLabels';
-import type { CosmosGraphCanvasRef, GraphCanvasProps } from './GraphCanvas';
+import type {
+  CosmosGraphCanvasRef,
+  CosmosGraphControls,
+  GraphCanvasProps
+} from './GraphCanvas';
 import css from './GraphCanvas.module.css';
 
 interface ResizableCosmosGraph {
@@ -77,6 +82,8 @@ export const CosmosGraphCanvas = forwardRef<
       contextMenu,
       edgeLabelPosition,
       onCanvasClick,
+      onLasso,
+      onLassoEnd,
       onNodeContextMenu,
       onNodeClick,
       onNodeDoubleClick,
@@ -107,14 +114,17 @@ export const CosmosGraphCanvas = forwardRef<
     );
     const hoveredNodeIdRef = useRef<string | null>(null);
     const hoveredEdgeIdRef = useRef<string | null>(null);
+    const lassoElementRef = useRef<HTMLDivElement | null>(null);
+    const lassoStartRef = useRef<[number, number] | null>(null);
     const [preparedGraph, setPreparedGraph] = useState<PreparedCosmosGraph>(
       preparedRef.current
     );
     const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
     const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
+    const [lassoActives, setLassoActives] = useState<string[]>([]);
     const selectedIds = useMemo(() => new Set(selections), [selections]);
     const activeIds = useMemo(() => {
-      const ids = new Set(actives);
+      const ids = new Set([...actives, ...lassoActives]);
       if (hoveredNodeId) {
         ids.add(hoveredNodeId);
       }
@@ -123,7 +133,7 @@ export const CosmosGraphCanvas = forwardRef<
       }
 
       return ids;
-    }, [actives, hoveredEdgeId, hoveredNodeId]);
+    }, [actives, hoveredEdgeId, hoveredNodeId, lassoActives]);
     const labelMaxCount =
       cosmosConfig?.labelMaxCount ?? DEFAULT_COSMOS_LABEL_MAX_COUNT;
     const labelUpdateInterval =
@@ -169,59 +179,121 @@ export const CosmosGraphCanvas = forwardRef<
       [collapsedNodeIds]
     );
 
+    const centerGraph = useCallback(
+      (nodeIds?: string[], opts?: { animated?: boolean }) => {
+        const graph = cosmosRef.current;
+        if (!graph) return;
+
+        const duration = opts?.animated === false ? 0 : 250;
+        const indices = getNodeIndices(nodeIds);
+
+        if (
+          !indices.length ||
+          indices.length === preparedRef.current.nodes.length
+        ) {
+          graph.fitView(duration, 0.1);
+        } else if (indices.length === 1) {
+          graph.zoomToPointByIndex(indices[0], duration);
+        } else {
+          graph.fitViewByPointIndices(indices, duration, 0.1);
+        }
+      },
+      [getNodeIndices]
+    );
+
+    const fitNodesInView = useCallback(
+      (nodeIds?: string[], opts?: { animated?: boolean }) => {
+        const graph = cosmosRef.current;
+        if (!graph) return;
+
+        graph.fitViewByPointIndices(
+          getNodeIndices(nodeIds),
+          opts?.animated === false ? 0 : 250,
+          0.1
+        );
+      },
+      [getNodeIndices]
+    );
+
+    const zoomIn = useCallback(() => {
+      const graph = cosmosRef.current;
+      graph?.zoom(graph.getZoomLevel() * 1.5, 250);
+    }, []);
+
+    const zoomOut = useCallback(() => {
+      const graph = cosmosRef.current;
+      graph?.zoom(graph.getZoomLevel() / 1.5, 250);
+    }, []);
+
+    const resetControls = useCallback(
+      (animated?: boolean) =>
+        cosmosRef.current?.fitView(animated === false ? 0 : 250, 0.1),
+      []
+    );
+
+    const freeze = useCallback(() => cosmosRef.current?.pause(), []);
+    const unFreeze = useCallback(() => cosmosRef.current?.unpause(), []);
+    const getCosmosGraph = useCallback(
+      () => cosmosRef.current ?? undefined,
+      []
+    );
+
+    const getControls = useCallback(
+      (): CosmosGraphControls => ({
+        centerGraph,
+        fitView: (duration?: number, padding?: number) =>
+          cosmosRef.current?.fitView(duration, padding),
+        fitNodesInView,
+        freeze,
+        getCosmosGraph,
+        resetControls,
+        unFreeze,
+        zoomIn,
+        zoomOut
+      }),
+      [
+        centerGraph,
+        fitNodesInView,
+        freeze,
+        getCosmosGraph,
+        resetControls,
+        unFreeze,
+        zoomIn,
+        zoomOut
+      ]
+    );
+
     useImperativeHandle(
       ref,
       () => ({
-        centerGraph: (nodeIds, opts) => {
-          const graph = cosmosRef.current;
-          if (!graph) return;
-
-          const duration = opts?.animated === false ? 0 : 250;
-          const indices = getNodeIndices(nodeIds);
-
-          if (
-            !indices.length ||
-            indices.length === preparedRef.current.nodes.length
-          ) {
-            graph.fitView(duration, 0.1);
-          } else if (indices.length === 1) {
-            graph.zoomToPointByIndex(indices[0], duration);
-          } else {
-            graph.fitViewByPointIndices(indices, duration, 0.1);
-          }
-        },
-        fitNodesInView: (nodeIds, opts) => {
-          const graph = cosmosRef.current;
-          if (!graph) return;
-
-          graph.fitViewByPointIndices(
-            getNodeIndices(nodeIds),
-            opts?.animated === false ? 0 : 250,
-            0.1
-          );
-        },
-        zoomIn: () => {
-          const graph = cosmosRef.current;
-          graph?.zoom(graph.getZoomLevel() * 1.5, 250);
-        },
-        zoomOut: () => {
-          const graph = cosmosRef.current;
-          graph?.zoom(graph.getZoomLevel() / 1.5, 250);
-        },
-        resetControls: (animated?: boolean) =>
-          cosmosRef.current?.fitView(animated === false ? 0 : 250, 0.1),
+        centerGraph,
+        fitNodesInView,
+        zoomIn,
+        zoomOut,
+        resetControls,
         getGraph: () => preparedRef.current.graph,
-        getCosmosGraph: () => cosmosRef.current ?? undefined,
+        getControls,
+        getCosmosGraph,
         exportCanvas: () => {
           cosmosRef.current?.render(0);
           return (
             containerRef.current?.querySelector('canvas')?.toDataURL() ?? ''
           );
         },
-        freeze: () => cosmosRef.current?.pause(),
-        unFreeze: () => cosmosRef.current?.unpause()
+        freeze,
+        unFreeze
       }),
-      [getNodeIndices]
+      [
+        centerGraph,
+        fitNodesInView,
+        freeze,
+        getControls,
+        getCosmosGraph,
+        resetControls,
+        unFreeze,
+        zoomIn,
+        zoomOut
+      ]
     );
 
     const config = useMemo(
@@ -451,6 +523,139 @@ export const CosmosGraphCanvas = forwardRef<
     ]);
 
     useEffect(() => {
+      const container = containerRef.current;
+      if (
+        disabled ||
+        !container ||
+        !lassoType ||
+        lassoType === 'none' ||
+        lassoType === 'edge'
+      ) {
+        return undefined;
+      }
+
+      const getSelectionRect = (event: PointerEvent) => {
+        const graph = cosmosRef.current;
+        const start = lassoStartRef.current;
+        if (!graph || !start) return undefined;
+
+        const bounds = container.getBoundingClientRect();
+        const current: [number, number] = [
+          event.clientX - bounds.left,
+          event.clientY - bounds.top
+        ];
+        const left = Math.max(0, Math.min(start[0], current[0]));
+        const right = Math.min(bounds.width, Math.max(start[0], current[0]));
+        const top = Math.max(0, Math.min(start[1], current[1]));
+        const bottom = Math.min(bounds.height, Math.max(start[1], current[1]));
+
+        return {
+          graph,
+          rect: [
+            [left, top],
+            [right, bottom]
+          ] as [[number, number], [number, number]]
+        };
+      };
+
+      const updateLassoElement = (event: PointerEvent) => {
+        const start = lassoStartRef.current;
+        const element = lassoElementRef.current;
+        if (!start || !element) return;
+
+        const bounds = container.getBoundingClientRect();
+        const startClientX = bounds.left + start[0];
+        const startClientY = bounds.top + start[1];
+        const left = Math.min(startClientX, event.clientX);
+        const right = Math.max(startClientX, event.clientX);
+        const top = Math.min(startClientY, event.clientY);
+        const bottom = Math.max(startClientY, event.clientY);
+
+        element.style.left = `${left}px`;
+        element.style.top = `${top}px`;
+        element.style.width = `${right - left}px`;
+        element.style.height = `${bottom - top}px`;
+      };
+
+      const selectNodesInRect = (event: PointerEvent) => {
+        const selection = getSelectionRect(event);
+        if (!selection) return [];
+
+        return Array.from(selection.graph.getPointsInRect(selection.rect))
+          .map(index => preparedRef.current.nodes[index]?.id)
+          .filter((id): id is string => Boolean(id));
+      };
+
+      const handlePointerMove = (event: PointerEvent) => {
+        if (!lassoStartRef.current) return;
+
+        event.preventDefault();
+        updateLassoElement(event);
+
+        const selected = selectNodesInRect(event);
+        setLassoActives(selected);
+        onLasso?.(selected);
+      };
+
+      const handlePointerUp = (event: PointerEvent) => {
+        if (!lassoStartRef.current) return;
+
+        event.preventDefault();
+        updateLassoElement(event);
+
+        const selected = selectNodesInRect(event);
+        setLassoActives(selected);
+        onLassoEnd?.(selected);
+
+        lassoStartRef.current = null;
+        lassoElementRef.current?.parentElement?.removeChild(
+          lassoElementRef.current
+        );
+        lassoElementRef.current = null;
+
+        document.removeEventListener('pointermove', handlePointerMove, true);
+        document.removeEventListener('pointerup', handlePointerUp, true);
+      };
+
+      const handlePointerDown = (event: PointerEvent) => {
+        if (!event.shiftKey || event.button !== 0) return;
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+
+        const bounds = container.getBoundingClientRect();
+        lassoStartRef.current = [
+          event.clientX - bounds.left,
+          event.clientY - bounds.top
+        ];
+
+        const element = createElement(theme);
+        lassoElementRef.current = element;
+        container.appendChild(element);
+        element.style.left = `${event.clientX}px`;
+        element.style.top = `${event.clientY}px`;
+        element.style.width = '0px';
+        element.style.height = '0px';
+
+        document.addEventListener('pointermove', handlePointerMove, true);
+        document.addEventListener('pointerup', handlePointerUp, true);
+      };
+
+      container.addEventListener('pointerdown', handlePointerDown, true);
+
+      return () => {
+        container.removeEventListener('pointerdown', handlePointerDown, true);
+        document.removeEventListener('pointermove', handlePointerMove, true);
+        document.removeEventListener('pointerup', handlePointerUp, true);
+        lassoElementRef.current?.parentElement?.removeChild(
+          lassoElementRef.current
+        );
+        lassoElementRef.current = null;
+        lassoStartRef.current = null;
+      };
+    }, [disabled, lassoType, onLasso, onLassoEnd, theme]);
+
+    useEffect(() => {
       if (typeof console === 'undefined') {
         return;
       }
@@ -459,7 +664,7 @@ export const CosmosGraphCanvas = forwardRef<
         children ? 'children' : undefined,
         contextMenu ? 'contextMenu' : undefined,
         edgeLabelPosition ? 'edgeLabelPosition' : undefined,
-        lassoType && lassoType !== 'none' ? 'lassoType' : undefined,
+        lassoType === 'edge' ? 'lassoType="edge"' : undefined,
         renderNode ? 'renderNode' : undefined,
         onRenderCluster ? 'onRenderCluster' : undefined,
         onClusterClick ? 'onClusterClick' : undefined,
@@ -544,7 +749,7 @@ export const CosmosGraphCanvas = forwardRef<
 
       const activeEdgeIds = new Set(actives);
       const colorActiveEdgeIds = new Set(actives);
-      const activeNodeIds = new Set(actives);
+      const activeNodeIds = new Set([...actives, ...lassoActives]);
       if (hoveredEdgeId) {
         colorActiveEdgeIds.add(hoveredEdgeId);
       }
@@ -591,6 +796,7 @@ export const CosmosGraphCanvas = forwardRef<
       edgeArrowPosition,
       hoveredEdgeId,
       hoveredNodeId,
+      lassoActives,
       preparedGraph,
       selections,
       selectedIds,

--- a/src/GraphCanvas/CosmosGraphCanvas.tsx
+++ b/src/GraphCanvas/CosmosGraphCanvas.tsx
@@ -21,6 +21,11 @@ import {
   buildCosmosConfig,
   prepareCosmosGraph
 } from './cosmos';
+import {
+  CosmosLabels,
+  DEFAULT_COSMOS_LABEL_MAX_COUNT,
+  DEFAULT_COSMOS_LABEL_UPDATE_INTERVAL
+} from './CosmosLabels';
 import type { CosmosGraphCanvasRef, GraphCanvasProps } from './GraphCanvas';
 import css from './GraphCanvas.module.css';
 
@@ -69,13 +74,27 @@ export const CosmosGraphCanvas = forwardRef<
       edgeArrowPosition = 'end',
       aggregateEdges,
       cosmosConfig,
+      contextMenu,
+      edgeLabelPosition,
       onCanvasClick,
+      onNodeContextMenu,
       onNodeClick,
+      onNodeDoubleClick,
+      onNodeDragged,
       onNodePointerOver,
       onNodePointerOut,
+      onEdgeContextMenu,
       onEdgeClick,
       onEdgePointerOver,
-      onEdgePointerOut
+      onEdgePointerOut,
+      lassoType,
+      renderNode,
+      onRenderCluster,
+      onClusterClick,
+      onClusterDragged,
+      onClusterPointerOver,
+      onClusterPointerOut,
+      children
     },
     ref: Ref<CosmosGraphCanvasRef>
   ) => {
@@ -93,6 +112,22 @@ export const CosmosGraphCanvas = forwardRef<
     );
     const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
     const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
+    const selectedIds = useMemo(() => new Set(selections), [selections]);
+    const activeIds = useMemo(() => {
+      const ids = new Set(actives);
+      if (hoveredNodeId) {
+        ids.add(hoveredNodeId);
+      }
+      if (hoveredEdgeId) {
+        ids.add(hoveredEdgeId);
+      }
+
+      return ids;
+    }, [actives, hoveredEdgeId, hoveredNodeId]);
+    const labelMaxCount =
+      cosmosConfig?.labelMaxCount ?? DEFAULT_COSMOS_LABEL_MAX_COUNT;
+    const labelUpdateInterval =
+      cosmosConfig?.labelUpdateInterval ?? DEFAULT_COSMOS_LABEL_UPDATE_INTERVAL;
 
     const getNodeIndices = useCallback((nodeIds?: string[]) => {
       const prepared = preparedRef.current;
@@ -122,6 +157,16 @@ export const CosmosGraphCanvas = forwardRef<
       (index: number): InternalGraphEdge | undefined =>
         preparedRef.current.edges[index],
       []
+    );
+
+    const getNodeContextProps = useCallback(
+      (node: InternalGraphNode) => ({
+        canCollapse: preparedRef.current.edges.some(
+          edge => edge.source === node.id
+        ),
+        isCollapsed: collapsedNodeIds.includes(node.id)
+      }),
+      [collapsedNodeIds]
     );
 
     useImperativeHandle(
@@ -197,20 +242,10 @@ export const CosmosGraphCanvas = forwardRef<
           onPointClick: (index, _position, event) => {
             if (disabled) return;
 
-            const prepared = preparedRef.current;
             const node = getNodeByIndex(index);
             if (!node) return;
 
-            onNodeClick?.(
-              node,
-              {
-                canCollapse: prepared.edges.some(
-                  edge => edge.source === node.id
-                ),
-                isCollapsed: collapsedNodeIds.includes(node.id)
-              },
-              event as never
-            );
+            onNodeClick?.(node, getNodeContextProps(node), event as never);
           },
           onPointMouseOver: (index, _position, event) => {
             const node = getNodeByIndex(index);
@@ -259,10 +294,36 @@ export const CosmosGraphCanvas = forwardRef<
             if (edge) {
               onEdgePointerOut?.(edge, event as never);
             }
+          },
+          onPointDragEnd: event => {
+            if (disabled || !onNodeDragged) return;
+
+            const index = event.subject?.index;
+            const node =
+              typeof index === 'number' ? getNodeByIndex(index) : undefined;
+            const graph = cosmosRef.current;
+
+            if (!node || !graph) return;
+
+            const positions = graph.getPointPositions();
+            const offset = index * 2;
+            const nextNode = {
+              ...node,
+              position: {
+                ...node.position,
+                x: positions[offset] ?? node.position.x,
+                y: positions[offset + 1] ?? node.position.y
+              }
+            };
+
+            preparedRef.current.nodes[index] = nextNode;
+            setPreparedGraph(current =>
+              current === preparedRef.current ? { ...current } : current
+            );
+            onNodeDragged(nextNode);
           }
         }),
       [
-        collapsedNodeIds,
         cosmosConfig,
         defaultNodeSize,
         disabled,
@@ -270,12 +331,14 @@ export const CosmosGraphCanvas = forwardRef<
         edgeArrowPosition,
         edgeInterpolation,
         getEdgeByIndex,
+        getNodeContextProps,
         getNodeByIndex,
         onCanvasClick,
         onEdgeClick,
         onEdgePointerOut,
         onEdgePointerOver,
         onNodeClick,
+        onNodeDragged,
         onNodePointerOut,
         onNodePointerOver,
         theme
@@ -329,6 +392,101 @@ export const CosmosGraphCanvas = forwardRef<
     useEffect(() => {
       cosmosRef.current?.setConfig(config);
     }, [config]);
+
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) {
+        return undefined;
+      }
+
+      const handleDoubleClick = (event: MouseEvent) => {
+        if (disabled) return;
+
+        const node = preparedRef.current.nodes.find(
+          n => n.id === hoveredNodeIdRef.current
+        );
+
+        if (node) {
+          onNodeDoubleClick?.(node, event as never);
+        }
+      };
+
+      const handleContextMenu = (event: MouseEvent) => {
+        if (disabled) return;
+
+        const node = preparedRef.current.nodes.find(
+          n => n.id === hoveredNodeIdRef.current
+        );
+        if (node && onNodeContextMenu) {
+          event.preventDefault();
+          onNodeContextMenu(node, {
+            ...getNodeContextProps(node),
+            onCollapse: () => undefined
+          });
+          return;
+        }
+
+        const edge = preparedRef.current.edges.find(
+          e => e.id === hoveredEdgeIdRef.current
+        );
+        if (edge && onEdgeContextMenu) {
+          event.preventDefault();
+          onEdgeContextMenu(edge);
+        }
+      };
+
+      container.addEventListener('dblclick', handleDoubleClick);
+      container.addEventListener('contextmenu', handleContextMenu);
+
+      return () => {
+        container.removeEventListener('dblclick', handleDoubleClick);
+        container.removeEventListener('contextmenu', handleContextMenu);
+      };
+    }, [
+      disabled,
+      getNodeContextProps,
+      onEdgeContextMenu,
+      onNodeContextMenu,
+      onNodeDoubleClick
+    ]);
+
+    useEffect(() => {
+      if (typeof console === 'undefined') {
+        return;
+      }
+
+      const unsupportedProps = [
+        children ? 'children' : undefined,
+        contextMenu ? 'contextMenu' : undefined,
+        edgeLabelPosition ? 'edgeLabelPosition' : undefined,
+        lassoType && lassoType !== 'none' ? 'lassoType' : undefined,
+        renderNode ? 'renderNode' : undefined,
+        onRenderCluster ? 'onRenderCluster' : undefined,
+        onClusterClick ? 'onClusterClick' : undefined,
+        onClusterDragged ? 'onClusterDragged' : undefined,
+        onClusterPointerOver ? 'onClusterPointerOver' : undefined,
+        onClusterPointerOut ? 'onClusterPointerOut' : undefined
+      ].filter(Boolean);
+
+      if (unsupportedProps.length) {
+        console.warn(
+          `GraphCanvas renderEngine="cosmos" does not currently support: ${unsupportedProps.join(
+            ', '
+          )}. These props are only handled by the Three.js renderer.`
+        );
+      }
+    }, [
+      children,
+      contextMenu,
+      edgeLabelPosition,
+      lassoType,
+      onClusterClick,
+      onClusterDragged,
+      onClusterPointerOut,
+      onClusterPointerOver,
+      onRenderCluster,
+      renderNode
+    ]);
 
     useEffect(() => {
       let cancelled = false;
@@ -402,7 +560,7 @@ export const CosmosGraphCanvas = forwardRef<
         edgeArrowPosition,
         hasSelections: selections.length > 0,
         preparedGraph,
-        selectedIds: new Set(selections),
+        selectedIds,
         theme
       });
 
@@ -435,12 +593,25 @@ export const CosmosGraphCanvas = forwardRef<
       hoveredNodeId,
       preparedGraph,
       selections,
+      selectedIds,
       theme
     ]);
 
     return (
       <div className={css.canvas}>
         <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+        <CosmosLabels
+          activeIds={activeIds}
+          containerRef={containerRef}
+          defaultNodeSize={defaultNodeSize}
+          graphRef={cosmosRef}
+          labelType={labelType}
+          maxCount={labelMaxCount}
+          preparedGraph={preparedGraph}
+          selectedIds={selectedIds}
+          theme={theme}
+          updateInterval={labelUpdateInterval}
+        />
       </div>
     );
   }

--- a/src/GraphCanvas/CosmosGraphCanvas.tsx
+++ b/src/GraphCanvas/CosmosGraphCanvas.tsx
@@ -1,0 +1,447 @@
+import { Graph as CosmosGraph } from '@cosmos.gl/graph';
+import type Graph from 'graphology';
+import Graphology from 'graphology';
+import type { Ref } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import { lightTheme } from '../themes';
+import type { InternalGraphEdge, InternalGraphNode } from '../types';
+import type { PreparedCosmosGraph } from './cosmos';
+import {
+  applyCosmosBuffers,
+  buildCosmosBuffers,
+  buildCosmosConfig,
+  prepareCosmosGraph
+} from './cosmos';
+import type { CosmosGraphCanvasRef, GraphCanvasProps } from './GraphCanvas';
+import css from './GraphCanvas.module.css';
+
+interface ResizableCosmosGraph {
+  resizeCanvas?: (force?: boolean) => void;
+}
+
+const EMPTY_IDS: string[] = [];
+
+const emptyPreparedGraph = (graph: Graph): PreparedCosmosGraph => ({
+  graph,
+  nodes: [],
+  edges: [],
+  nodeIndexById: new Map()
+});
+
+const resizeCosmosGraph = (graph: CosmosGraph) => {
+  (graph as unknown as ResizableCosmosGraph).resizeCanvas?.(true);
+};
+
+export const CosmosGraphCanvas = forwardRef<
+  CosmosGraphCanvasRef,
+  GraphCanvasProps
+>(
+  (
+    {
+      layoutType = 'forceDirected2d',
+      sizingType = 'default',
+      labelType = 'auto',
+      theme = lightTheme,
+      animated = true,
+      defaultNodeSize = 7,
+      minNodeSize = 5,
+      maxNodeSize = 15,
+      edges,
+      nodes,
+      disabled,
+      draggable,
+      selections = EMPTY_IDS,
+      actives = EMPTY_IDS,
+      collapsedNodeIds = EMPTY_IDS,
+      sizingAttribute,
+      clusterAttribute,
+      layoutOverrides,
+      edgeInterpolation = 'linear',
+      edgeArrowPosition = 'end',
+      aggregateEdges,
+      cosmosConfig,
+      onCanvasClick,
+      onNodeClick,
+      onNodePointerOver,
+      onNodePointerOut,
+      onEdgeClick,
+      onEdgePointerOver,
+      onEdgePointerOut
+    },
+    ref: Ref<CosmosGraphCanvasRef>
+  ) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const cosmosRef = useRef<CosmosGraph | null>(null);
+    const graphRef = useRef<Graph>(new Graphology({ multi: true }));
+    const didFitViewRef = useRef(false);
+    const preparedRef = useRef<PreparedCosmosGraph>(
+      emptyPreparedGraph(graphRef.current)
+    );
+    const hoveredNodeIdRef = useRef<string | null>(null);
+    const hoveredEdgeIdRef = useRef<string | null>(null);
+    const [preparedGraph, setPreparedGraph] = useState<PreparedCosmosGraph>(
+      preparedRef.current
+    );
+    const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+    const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
+
+    const getNodeIndices = useCallback((nodeIds?: string[]) => {
+      const prepared = preparedRef.current;
+
+      if (!nodeIds?.length) {
+        return prepared.nodes.map((_, index) => index);
+      }
+
+      return nodeIds.reduce<number[]>((indices, id) => {
+        const index = prepared.nodeIndexById.get(id);
+        if (index === undefined) {
+          throw new Error(`Attempted to center ${id} but it was not found.`);
+        }
+
+        indices.push(index);
+        return indices;
+      }, []);
+    }, []);
+
+    const getNodeByIndex = useCallback(
+      (index: number): InternalGraphNode | undefined =>
+        preparedRef.current.nodes[index],
+      []
+    );
+
+    const getEdgeByIndex = useCallback(
+      (index: number): InternalGraphEdge | undefined =>
+        preparedRef.current.edges[index],
+      []
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        centerGraph: (nodeIds, opts) => {
+          const graph = cosmosRef.current;
+          if (!graph) return;
+
+          const duration = opts?.animated === false ? 0 : 250;
+          const indices = getNodeIndices(nodeIds);
+
+          if (
+            !indices.length ||
+            indices.length === preparedRef.current.nodes.length
+          ) {
+            graph.fitView(duration, 0.1);
+          } else if (indices.length === 1) {
+            graph.zoomToPointByIndex(indices[0], duration);
+          } else {
+            graph.fitViewByPointIndices(indices, duration, 0.1);
+          }
+        },
+        fitNodesInView: (nodeIds, opts) => {
+          const graph = cosmosRef.current;
+          if (!graph) return;
+
+          graph.fitViewByPointIndices(
+            getNodeIndices(nodeIds),
+            opts?.animated === false ? 0 : 250,
+            0.1
+          );
+        },
+        zoomIn: () => {
+          const graph = cosmosRef.current;
+          graph?.zoom(graph.getZoomLevel() * 1.5, 250);
+        },
+        zoomOut: () => {
+          const graph = cosmosRef.current;
+          graph?.zoom(graph.getZoomLevel() / 1.5, 250);
+        },
+        resetControls: (animated?: boolean) =>
+          cosmosRef.current?.fitView(animated === false ? 0 : 250, 0.1),
+        getGraph: () => preparedRef.current.graph,
+        getCosmosGraph: () => cosmosRef.current ?? undefined,
+        exportCanvas: () => {
+          cosmosRef.current?.render(0);
+          return (
+            containerRef.current?.querySelector('canvas')?.toDataURL() ?? ''
+          );
+        },
+        freeze: () => cosmosRef.current?.pause(),
+        unFreeze: () => cosmosRef.current?.unpause()
+      }),
+      [getNodeIndices]
+    );
+
+    const config = useMemo(
+      () =>
+        buildCosmosConfig({
+          config: cosmosConfig,
+          defaultNodeSize,
+          disabled,
+          draggable,
+          edgeArrowPosition,
+          edgeInterpolation,
+          theme,
+          onBackgroundClick: event => {
+            if (!disabled) {
+              onCanvasClick?.(event);
+            }
+          },
+          onPointClick: (index, _position, event) => {
+            if (disabled) return;
+
+            const prepared = preparedRef.current;
+            const node = getNodeByIndex(index);
+            if (!node) return;
+
+            onNodeClick?.(
+              node,
+              {
+                canCollapse: prepared.edges.some(
+                  edge => edge.source === node.id
+                ),
+                isCollapsed: collapsedNodeIds.includes(node.id)
+              },
+              event as never
+            );
+          },
+          onPointMouseOver: (index, _position, event) => {
+            const node = getNodeByIndex(index);
+            if (!node) return;
+
+            hoveredNodeIdRef.current = node.id;
+            setHoveredNodeId(node.id);
+            onNodePointerOver?.(node, event as never);
+          },
+          onPointMouseOut: event => {
+            const node = preparedRef.current.nodes.find(
+              n => n.id === hoveredNodeIdRef.current
+            );
+
+            hoveredNodeIdRef.current = null;
+            setHoveredNodeId(null);
+
+            if (node) {
+              onNodePointerOut?.(node, event as never);
+            }
+          },
+          onLinkClick: (index, event) => {
+            if (disabled) return;
+
+            const edge = getEdgeByIndex(index);
+            if (edge) {
+              onEdgeClick?.(edge, event as never);
+            }
+          },
+          onLinkMouseOver: index => {
+            const edge = getEdgeByIndex(index);
+            if (!edge) return;
+
+            hoveredEdgeIdRef.current = edge.id;
+            setHoveredEdgeId(edge.id);
+            onEdgePointerOver?.(edge, undefined as never);
+          },
+          onLinkMouseOut: event => {
+            const edge = preparedRef.current.edges.find(
+              e => e.id === hoveredEdgeIdRef.current
+            );
+
+            hoveredEdgeIdRef.current = null;
+            setHoveredEdgeId(null);
+
+            if (edge) {
+              onEdgePointerOut?.(edge, event as never);
+            }
+          }
+        }),
+      [
+        collapsedNodeIds,
+        cosmosConfig,
+        defaultNodeSize,
+        disabled,
+        draggable,
+        edgeArrowPosition,
+        edgeInterpolation,
+        getEdgeByIndex,
+        getNodeByIndex,
+        onCanvasClick,
+        onEdgeClick,
+        onEdgePointerOut,
+        onEdgePointerOver,
+        onNodeClick,
+        onNodePointerOut,
+        onNodePointerOver,
+        theme
+      ]
+    );
+
+    useEffect(() => {
+      if (!containerRef.current || cosmosRef.current) {
+        return undefined;
+      }
+
+      const graph = new CosmosGraph(containerRef.current, config);
+      cosmosRef.current = graph;
+
+      return () => {
+        graph.destroy();
+        cosmosRef.current = null;
+      };
+      // Create the cosmos renderer once; config updates are applied below.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container || typeof ResizeObserver === 'undefined') {
+        return undefined;
+      }
+
+      const observer = new ResizeObserver(() => {
+        const graph = cosmosRef.current;
+        if (!graph || !container.clientWidth || !container.clientHeight) {
+          return;
+        }
+
+        resizeCosmosGraph(graph);
+        graph.render(animated ? undefined : 0);
+
+        if (!didFitViewRef.current && preparedRef.current.nodes.length) {
+          graph.fitView(0, 0.1);
+          didFitViewRef.current = true;
+        }
+      });
+
+      observer.observe(container);
+
+      return () => {
+        observer.disconnect();
+      };
+    }, [animated]);
+
+    useEffect(() => {
+      cosmosRef.current?.setConfig(config);
+    }, [config]);
+
+    useEffect(() => {
+      let cancelled = false;
+
+      async function updateGraph() {
+        const prepared = await prepareCosmosGraph({
+          graph: graphRef.current,
+          nodes,
+          edges,
+          aggregateEdges,
+          collapsedNodeIds,
+          clusterAttribute,
+          defaultNodeSize,
+          labelType,
+          layoutOverrides,
+          layoutType,
+          maxNodeSize,
+          minNodeSize,
+          sizingAttribute,
+          sizingType
+        });
+
+        if (!cancelled) {
+          preparedRef.current = prepared;
+          setPreparedGraph(prepared);
+        }
+      }
+
+      updateGraph();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [
+      aggregateEdges,
+      collapsedNodeIds,
+      clusterAttribute,
+      defaultNodeSize,
+      edges,
+      labelType,
+      layoutOverrides,
+      layoutType,
+      maxNodeSize,
+      minNodeSize,
+      nodes,
+      sizingAttribute,
+      sizingType
+    ]);
+
+    useEffect(() => {
+      const graph = cosmosRef.current;
+      if (!graph) {
+        return undefined;
+      }
+
+      const activeEdgeIds = new Set(actives);
+      const colorActiveEdgeIds = new Set(actives);
+      const activeNodeIds = new Set(actives);
+      if (hoveredEdgeId) {
+        colorActiveEdgeIds.add(hoveredEdgeId);
+      }
+      if (hoveredNodeId) {
+        activeNodeIds.add(hoveredNodeId);
+      }
+
+      const buffers = buildCosmosBuffers({
+        activeEdgeIds,
+        activeNodeIds,
+        colorActiveEdgeIds,
+        defaultNodeSize,
+        edgeArrowPosition,
+        hasSelections: selections.length > 0,
+        preparedGraph,
+        selectedIds: new Set(selections),
+        theme
+      });
+
+      applyCosmosBuffers(graph, buffers, animated);
+
+      const frameId = requestAnimationFrame(() => {
+        if (cosmosRef.current !== graph) {
+          return;
+        }
+
+        resizeCosmosGraph(graph);
+
+        if (!didFitViewRef.current && preparedGraph.nodes.length) {
+          graph.fitView(0, 0.1);
+          didFitViewRef.current = true;
+        }
+
+        graph.render(animated ? undefined : 0);
+      });
+
+      return () => {
+        cancelAnimationFrame(frameId);
+      };
+    }, [
+      actives,
+      animated,
+      defaultNodeSize,
+      edgeArrowPosition,
+      hoveredEdgeId,
+      hoveredNodeId,
+      preparedGraph,
+      selections,
+      theme
+    ]);
+
+    return (
+      <div className={css.canvas}>
+        <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+      </div>
+    );
+  }
+);

--- a/src/GraphCanvas/CosmosLabels.tsx
+++ b/src/GraphCanvas/CosmosLabels.tsx
@@ -1,0 +1,363 @@
+import type { Graph as CosmosGraph } from '@cosmos.gl/graph';
+import React, { useEffect, useState } from 'react';
+
+import type { Theme } from '../themes';
+import type { InternalGraphNode } from '../types';
+import type { PreparedCosmosGraph } from './cosmos';
+import { toHexColor } from './cosmos';
+import type { GraphCanvasProps } from './GraphCanvas';
+
+interface CosmosLabel {
+  active: boolean;
+  id: string;
+  label: string;
+  type: 'node' | 'edge';
+  x: number;
+  y: number;
+}
+
+type CosmosLabelType = NonNullable<GraphCanvasProps['labelType']>;
+
+export const DEFAULT_COSMOS_LABEL_MAX_COUNT = 150;
+export const DEFAULT_COSMOS_LABEL_UPDATE_INTERVAL = 50;
+
+const LABEL_MARGIN = 24;
+
+const areLabelsEqual = (a: CosmosLabel[], b: CosmosLabel[]) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((label, index) => {
+    const next = b[index];
+
+    return (
+      label.active === next.active &&
+      label.id === next.id &&
+      label.label === next.label &&
+      label.type === next.type &&
+      Math.abs(label.x - next.x) < 1 &&
+      Math.abs(label.y - next.y) < 1
+    );
+  });
+};
+
+const isVisibleScreenPosition = (
+  x: number,
+  y: number,
+  container: HTMLDivElement
+) =>
+  x >= LABEL_MARGIN &&
+  y >= LABEL_MARGIN &&
+  x <= container.clientWidth - LABEL_MARGIN &&
+  y <= container.clientHeight - LABEL_MARGIN;
+
+const getPointPosition = (
+  graph: CosmosGraph,
+  node: InternalGraphNode,
+  index: number
+): [number, number] => {
+  const positions = graph.getPointPositions();
+  const offset = index * 2;
+
+  return [
+    positions[offset] ?? node.position.x,
+    positions[offset + 1] ?? node.position.y
+  ];
+};
+
+const getNodeLabels = (
+  graph: CosmosGraph,
+  preparedGraph: PreparedCosmosGraph,
+  selectedIds: Set<string>,
+  activeIds: Set<string>,
+  labelType: CosmosLabelType,
+  defaultNodeSize: number,
+  maxCount: number
+): CosmosLabel[] => {
+  const labels: CosmosLabel[] = [];
+  const sampledPositions =
+    labelType === 'auto' ? graph.getSampledPointPositionsMap() : undefined;
+  const zoom = graph.getZoomLevel();
+
+  for (let index = 0; index < preparedGraph.nodes.length; index += 1) {
+    const node = preparedGraph.nodes[index];
+    if (!node.label || node.labelVisible === false) {
+      continue;
+    }
+
+    if (
+      labelType === 'auto' &&
+      !sampledPositions?.has(index) &&
+      (node.size ?? defaultNodeSize) <= defaultNodeSize &&
+      zoom < 1.5
+    ) {
+      continue;
+    }
+
+    const [x, y] = graph.spaceToScreenPosition(
+      sampledPositions?.get(index) ?? getPointPosition(graph, node, index)
+    );
+
+    labels.push({
+      active: selectedIds.has(node.id) || activeIds.has(node.id),
+      id: node.id,
+      label: node.label,
+      type: 'node',
+      x,
+      y
+    });
+
+    if (labels.length >= maxCount) {
+      break;
+    }
+  }
+
+  return labels;
+};
+
+const getEdgeLabels = (
+  graph: CosmosGraph,
+  preparedGraph: PreparedCosmosGraph,
+  selectedIds: Set<string>,
+  activeIds: Set<string>,
+  maxCount: number
+): CosmosLabel[] => {
+  const labels: CosmosLabel[] = [];
+
+  for (const edge of preparedGraph.edges) {
+    if (!edge.label || edge.labelVisible === false) {
+      continue;
+    }
+
+    const sourceIndex = preparedGraph.nodeIndexById.get(edge.source);
+    const targetIndex = preparedGraph.nodeIndexById.get(edge.target);
+    if (sourceIndex === undefined || targetIndex === undefined) {
+      continue;
+    }
+
+    const source = preparedGraph.nodes[sourceIndex];
+    const target = preparedGraph.nodes[targetIndex];
+    const sourcePosition = getPointPosition(graph, source, sourceIndex);
+    const targetPosition = getPointPosition(graph, target, targetIndex);
+    const [x, y] = graph.spaceToScreenPosition([
+      (sourcePosition[0] + targetPosition[0]) / 2,
+      (sourcePosition[1] + targetPosition[1]) / 2
+    ]);
+
+    labels.push({
+      active: selectedIds.has(edge.id) || activeIds.has(edge.id),
+      id: edge.id,
+      label: edge.label,
+      type: 'edge',
+      x,
+      y
+    });
+
+    if (labels.length >= maxCount) {
+      break;
+    }
+  }
+
+  return labels;
+};
+
+const getCosmosLabels = ({
+  activeIds,
+  container,
+  defaultNodeSize,
+  graph,
+  labelType,
+  maxCount,
+  preparedGraph,
+  selectedIds
+}: {
+  activeIds: Set<string>;
+  container: HTMLDivElement;
+  defaultNodeSize: number;
+  graph: CosmosGraph;
+  labelType: CosmosLabelType;
+  maxCount: number;
+  preparedGraph: PreparedCosmosGraph;
+  selectedIds: Set<string>;
+}) => {
+  if (labelType === 'none') {
+    return [];
+  }
+
+  const labels: CosmosLabel[] = [];
+
+  if (labelType === 'auto' || labelType === 'all' || labelType === 'nodes') {
+    labels.push(
+      ...getNodeLabels(
+        graph,
+        preparedGraph,
+        selectedIds,
+        activeIds,
+        labelType,
+        defaultNodeSize,
+        maxCount
+      )
+    );
+  }
+
+  if (
+    (labelType === 'all' || labelType === 'edges') &&
+    labels.length < maxCount
+  ) {
+    labels.push(
+      ...getEdgeLabels(
+        graph,
+        preparedGraph,
+        selectedIds,
+        activeIds,
+        maxCount - labels.length
+      )
+    );
+  }
+
+  return labels.filter(label =>
+    isVisibleScreenPosition(label.x, label.y, container)
+  );
+};
+
+export const CosmosLabels = ({
+  activeIds,
+  containerRef,
+  defaultNodeSize,
+  graphRef,
+  labelType,
+  maxCount,
+  preparedGraph,
+  selectedIds,
+  theme,
+  updateInterval
+}: {
+  activeIds: Set<string>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  defaultNodeSize: number;
+  graphRef: React.RefObject<CosmosGraph | null>;
+  labelType: CosmosLabelType;
+  maxCount: number;
+  preparedGraph: PreparedCosmosGraph;
+  selectedIds: Set<string>;
+  theme: Theme;
+  updateInterval: number;
+}) => {
+  const [labels, setLabels] = useState<CosmosLabel[]>([]);
+
+  useEffect(() => {
+    if (labelType === 'none') {
+      setLabels(labels => (labels.length ? [] : labels));
+      return undefined;
+    }
+
+    let frameId = 0;
+    let lastUpdate = 0;
+    let lastLabels: CosmosLabel[] = [];
+
+    const update = (now: number) => {
+      const graph = graphRef.current;
+      const container = containerRef.current;
+
+      if (
+        graph &&
+        container &&
+        preparedGraph.nodes.length &&
+        now - lastUpdate >= updateInterval
+      ) {
+        const nextLabels = getCosmosLabels({
+          activeIds,
+          container,
+          defaultNodeSize,
+          graph,
+          labelType,
+          maxCount,
+          preparedGraph,
+          selectedIds
+        });
+
+        if (!areLabelsEqual(nextLabels, lastLabels)) {
+          lastLabels = nextLabels;
+          setLabels(nextLabels);
+        }
+
+        lastUpdate = now;
+      }
+
+      frameId = requestAnimationFrame(update);
+    };
+
+    frameId = requestAnimationFrame(update);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [
+    activeIds,
+    containerRef,
+    defaultNodeSize,
+    graphRef,
+    labelType,
+    maxCount,
+    preparedGraph,
+    selectedIds,
+    updateInterval
+  ]);
+
+  if (!labels.length) {
+    return null;
+  }
+
+  const nodeColor = toHexColor(theme.node.label.color, '#2A6475');
+  const nodeActiveColor = toHexColor(theme.node.label.activeColor, '#1DE9AC');
+  const nodeStroke = toHexColor(theme.node.label.stroke, '#fff');
+  const edgeColor = toHexColor(theme.edge.label.color, '#2A6475');
+  const edgeActiveColor = toHexColor(theme.edge.label.activeColor, '#1DE9AC');
+  const edgeStroke = toHexColor(theme.edge.label.stroke, '#fff');
+
+  return (
+    <>
+      {labels.map(label => {
+        const isNode = label.type === 'node';
+        const color = label.active
+          ? isNode
+            ? nodeActiveColor
+            : edgeActiveColor
+          : isNode
+            ? nodeColor
+            : edgeColor;
+        const stroke = isNode ? nodeStroke : edgeStroke;
+
+        return (
+          <div
+            key={`${label.type}-${label.id}`}
+            style={{
+              color,
+              fontSize: isNode
+                ? 12
+                : Math.max(theme.edge.label.fontSize ?? 10, 10),
+              fontWeight: isNode ? 600 : 500,
+              left: label.x,
+              maxWidth: 160,
+              overflow: 'hidden',
+              pointerEvents: 'none',
+              position: 'absolute',
+              textAlign: 'center',
+              textOverflow: 'ellipsis',
+              textShadow: `-1px -1px 0 ${stroke}, 1px -1px 0 ${stroke}, -1px 1px 0 ${stroke}, 1px 1px 0 ${stroke}`,
+              top: label.y,
+              transform: isNode
+                ? 'translate(-50%, -150%)'
+                : 'translate(-50%, -50%)',
+              whiteSpace: 'nowrap',
+              zIndex: 8
+            }}
+          >
+            {label.label}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/GraphCanvas/GraphCanvas.test.ts
+++ b/src/GraphCanvas/GraphCanvas.test.ts
@@ -1,0 +1,108 @@
+import React, { act, createRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import type { CosmosGraphCanvasRef, GraphCanvasRef } from './GraphCanvas';
+import { GraphCanvas } from './GraphCanvas';
+
+const { graphInstances, MockCosmosGraph } = vi.hoisted(() => {
+  class MockCosmosGraph {
+    config: unknown;
+    destroyed = false;
+
+    constructor(_container: HTMLDivElement, config: unknown) {
+      this.config = config;
+      graphInstances.push(this);
+    }
+
+    destroy = vi.fn(() => {
+      this.destroyed = true;
+    });
+    fitView = vi.fn();
+    fitViewByPointIndices = vi.fn();
+    getPointPositions = vi.fn(() => []);
+    getZoomLevel = vi.fn(() => 1);
+    pause = vi.fn();
+    render = vi.fn();
+    setConfig = vi.fn();
+    setLinkArrows = vi.fn();
+    setLinkColors = vi.fn();
+    setLinks = vi.fn();
+    setLinkWidths = vi.fn();
+    setPointColors = vi.fn();
+    setPointPositions = vi.fn();
+    setPointSizes = vi.fn();
+    unpause = vi.fn();
+    zoom = vi.fn();
+    zoomToPointByIndex = vi.fn();
+  }
+
+  const graphInstances: MockCosmosGraph[] = [];
+
+  return { graphInstances, MockCosmosGraph };
+});
+
+vi.mock('@cosmos.gl/graph', () => ({
+  Graph: MockCosmosGraph
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  graphInstances.length = 0;
+  vi.clearAllMocks();
+});
+
+const emptyGraph = {
+  edges: [],
+  nodes: []
+};
+
+const typeCheckGraphCanvasRefs = () => {
+  const threeRef = createRef<GraphCanvasRef>();
+  const cosmosRef = createRef<CosmosGraphCanvasRef>();
+
+  GraphCanvas({ ref: threeRef, ...emptyGraph });
+  GraphCanvas({ ref: cosmosRef, renderEngine: 'cosmos', ...emptyGraph });
+
+  // @ts-expect-error Cosmos refs intentionally do not expose Three camera controls.
+  cosmosRef.current?.getControls();
+
+  // @ts-expect-error Three GraphCanvasRef is not valid for renderEngine="cosmos".
+  GraphCanvas({ ref: threeRef, renderEngine: 'cosmos', ...emptyGraph });
+};
+void typeCheckGraphCanvasRefs;
+
+describe('GraphCanvas cosmos renderer', () => {
+  test('mounts through GraphCanvas and exposes the cosmos ref contract', async () => {
+    const container = document.createElement('div');
+    const ref = createRef<CosmosGraphCanvasRef>();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(GraphCanvas, {
+          ref,
+          renderEngine: 'cosmos',
+          labelType: 'none',
+          nodes: [
+            { id: 'one', label: 'One' },
+            { id: 'two', label: 'Two' }
+          ],
+          edges: [{ id: 'edge', source: 'one', target: 'two' }]
+        })
+      );
+    });
+
+    expect(graphInstances).toHaveLength(1);
+    expect(ref.current?.getCosmosGraph()).toBe(graphInstances[0]);
+    expect('getControls' in ref.current!).toBe(false);
+    expect(graphInstances[0].setConfig).toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(graphInstances[0].destroy).toHaveBeenCalled();
+  });
+});

--- a/src/GraphCanvas/GraphCanvas.test.ts
+++ b/src/GraphCanvas/GraphCanvas.test.ts
@@ -21,6 +21,7 @@ const { graphInstances, MockCosmosGraph } = vi.hoisted(() => {
     fitView = vi.fn();
     fitViewByPointIndices = vi.fn();
     getPointPositions = vi.fn(() => []);
+    getPointsInRect = vi.fn(() => new Float32Array());
     getZoomLevel = vi.fn(() => 1);
     pause = vi.fn();
     render = vi.fn();
@@ -64,9 +65,7 @@ const typeCheckGraphCanvasRefs = () => {
 
   GraphCanvas({ ref: threeRef, ...emptyGraph });
   GraphCanvas({ ref: cosmosRef, renderEngine: 'cosmos', ...emptyGraph });
-
-  // @ts-expect-error Cosmos refs intentionally do not expose Three camera controls.
-  cosmosRef.current?.getControls();
+  cosmosRef.current?.getControls().getCosmosGraph();
 
   // @ts-expect-error Three GraphCanvasRef is not valid for renderEngine="cosmos".
   GraphCanvas({ ref: threeRef, renderEngine: 'cosmos', ...emptyGraph });
@@ -96,7 +95,9 @@ describe('GraphCanvas cosmos renderer', () => {
 
     expect(graphInstances).toHaveLength(1);
     expect(ref.current?.getCosmosGraph()).toBe(graphInstances[0]);
-    expect('getControls' in ref.current!).toBe(false);
+    expect(ref.current?.getControls().getCosmosGraph()).toBe(graphInstances[0]);
+    ref.current?.getControls().zoomIn();
+    expect(graphInstances[0].zoom).toHaveBeenCalledWith(1.5, 250);
     expect(graphInstances[0].setConfig).toHaveBeenCalled();
 
     await act(async () => {
@@ -104,5 +105,84 @@ describe('GraphCanvas cosmos renderer', () => {
     });
 
     expect(graphInstances[0].destroy).toHaveBeenCalled();
+  });
+
+  test('supports node lasso selection with the cosmos renderer', async () => {
+    const container = document.createElement('div');
+    const onLassoEnd = vi.fn();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(GraphCanvas, {
+          renderEngine: 'cosmos',
+          labelType: 'none',
+          lassoType: 'node',
+          nodes: [
+            { id: 'one', label: 'One' },
+            { id: 'two', label: 'Two' }
+          ],
+          edges: [{ id: 'edge', source: 'one', target: 'two' }],
+          onLassoEnd
+        })
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    graphInstances[0].getPointsInRect.mockReturnValue(new Float32Array([0, 1]));
+
+    const cosmosContainer = container.firstElementChild
+      ?.firstElementChild as HTMLDivElement;
+    cosmosContainer.getBoundingClientRect = () =>
+      ({
+        bottom: 100,
+        height: 100,
+        left: 0,
+        right: 100,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      }) as DOMRect;
+
+    await act(async () => {
+      cosmosContainer.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          clientX: 10,
+          clientY: 20,
+          shiftKey: true
+        })
+      );
+      document.dispatchEvent(
+        new MouseEvent('pointermove', {
+          bubbles: true,
+          clientX: 50,
+          clientY: 70
+        })
+      );
+      document.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          clientX: 50,
+          clientY: 70
+        })
+      );
+    });
+
+    expect(graphInstances[0].getPointsInRect).toHaveBeenCalledWith([
+      [10, 20],
+      [50, 70]
+    ]);
+    expect(onLassoEnd).toHaveBeenCalledWith(['one', 'two']);
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/src/GraphCanvas/GraphCanvas.tsx
+++ b/src/GraphCanvas/GraphCanvas.tsx
@@ -2,7 +2,7 @@ import type { Graph as CosmosGraph } from '@cosmos.gl/graph';
 import { Canvas } from '@react-three/fiber';
 import type ThreeCameraControls from 'camera-controls';
 import type Graph from 'graphology';
-import type { ReactNode, Ref } from 'react';
+import type { ReactElement, ReactNode, Ref, RefAttributes } from 'react';
 import React, {
   forwardRef,
   Suspense,
@@ -35,11 +35,17 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
 
   /**
    * Render engine to use for the graph. Defaults to the Three.js renderer.
+   *
+   * The cosmos renderer supports large 2D graphs, Reagraph styling, labels,
+   * node/edge click and hover, node double click, node/edge context menu, and
+   * node drag end callbacks. Three.js-only features such as lasso, custom
+   * renderers, children, and cluster rendering/events are ignored by cosmos.
    */
   renderEngine?: RenderEngine;
 
   /**
-   * Additional cosmos.gl configuration when renderEngine is "cosmos".
+   * Additional cosmos.gl configuration when renderEngine is "cosmos". Reagraph
+   * also accepts labelMaxCount and labelUpdateInterval for cosmos DOM labels.
    */
   cosmosConfig?: CosmosConfig;
 
@@ -102,6 +108,14 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
    * Whether to aggregate edges with the same source and target.
    */
   aggregateEdges?: boolean;
+}
+
+export interface ThreeGraphCanvasProps extends GraphCanvasProps {
+  renderEngine?: 'three';
+}
+
+export interface CosmosGraphCanvasProps extends GraphCanvasProps {
+  renderEngine: 'cosmos';
 }
 
 export interface BaseGraphCanvasRef
@@ -354,7 +368,16 @@ const ThreeGraphCanvas = forwardRef<ThreeGraphCanvasRef, GraphCanvasProps>(
   }
 );
 
-export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
+export interface GraphCanvasComponent {
+  (
+    props: ThreeGraphCanvasProps & RefAttributes<ThreeGraphCanvasRef>
+  ): ReactElement | null;
+  (
+    props: CosmosGraphCanvasProps & RefAttributes<CosmosGraphCanvasRef>
+  ): ReactElement | null;
+}
+
+const GraphCanvasComponent = forwardRef<BaseGraphCanvasRef, GraphCanvasProps>(
   (props, ref) =>
     props.renderEngine === 'cosmos' ? (
       <CosmosGraphCanvas
@@ -365,3 +388,5 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
       <ThreeGraphCanvas ref={ref as Ref<ThreeGraphCanvasRef>} {...props} />
     )
 );
+
+export const GraphCanvas = GraphCanvasComponent as GraphCanvasComponent;

--- a/src/GraphCanvas/GraphCanvas.tsx
+++ b/src/GraphCanvas/GraphCanvas.tsx
@@ -37,9 +37,10 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
    * Render engine to use for the graph. Defaults to the Three.js renderer.
    *
    * The cosmos renderer supports large 2D graphs, Reagraph styling, labels,
-   * node/edge click and hover, node double click, node/edge context menu, and
-   * node drag end callbacks. Three.js-only features such as lasso, custom
-   * renderers, children, and cluster rendering/events are ignored by cosmos.
+   * node/edge click and hover, node double click, node/edge context menu, node
+   * drag end callbacks, and node lasso selection. Three.js-only features such
+   * as edge lasso, custom renderers, children, and cluster rendering/events are
+   * ignored by cosmos.
    */
   renderEngine?: RenderEngine;
 
@@ -167,7 +168,59 @@ export interface ThreeGraphCanvasRef
 
 export type GraphCanvasRef = ThreeGraphCanvasRef;
 
+export interface CosmosGraphControls {
+  /**
+   * Center the graph on all nodes or the given node ids.
+   */
+  centerGraph: BaseGraphCanvasRef['centerGraph'];
+
+  /**
+   * Fit all nodes in view.
+   */
+  fitView: (duration?: number, padding?: number) => void;
+
+  /**
+   * Fit the given node ids in view.
+   */
+  fitNodesInView: BaseGraphCanvasRef['fitNodesInView'];
+
+  /**
+   * Freeze graph interactions.
+   */
+  freeze: BaseGraphCanvasRef['freeze'];
+
+  /**
+   * Get the cosmos.gl graph renderer.
+   */
+  getCosmosGraph: () => CosmosGraph | undefined;
+
+  /**
+   * Reset controls to the initial graph view.
+   */
+  resetControls: BaseGraphCanvasRef['resetControls'];
+
+  /**
+   * Unfreeze graph interactions.
+   */
+  unFreeze: BaseGraphCanvasRef['unFreeze'];
+
+  /**
+   * Zoom in on the graph.
+   */
+  zoomIn: BaseGraphCanvasRef['zoomIn'];
+
+  /**
+   * Zoom out on the graph.
+   */
+  zoomOut: BaseGraphCanvasRef['zoomOut'];
+}
+
 export interface CosmosGraphCanvasRef extends BaseGraphCanvasRef {
+  /**
+   * Get engine-specific controls for the cosmos renderer.
+   */
+  getControls: () => CosmosGraphControls;
+
   /**
    * Get the cosmos.gl graph renderer.
    */

--- a/src/GraphCanvas/GraphCanvas.tsx
+++ b/src/GraphCanvas/GraphCanvas.tsx
@@ -1,3 +1,4 @@
+import type { Graph as CosmosGraph } from '@cosmos.gl/graph';
 import { Canvas } from '@react-three/fiber';
 import type ThreeCameraControls from 'camera-controls';
 import type Graph from 'graphology';
@@ -20,13 +21,27 @@ import { Lasso } from '../selection/Lasso';
 import { createStore, Provider } from '../store';
 import type { Theme } from '../themes';
 import { lightTheme } from '../themes';
+import type { CosmosConfig } from './cosmos';
+import { CosmosGraphCanvas } from './CosmosGraphCanvas';
 import css from './GraphCanvas.module.css';
+
+export type RenderEngine = 'three' | 'cosmos';
 
 export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
   /**
    * Theme to use for the graph.
    */
   theme?: Theme;
+
+  /**
+   * Render engine to use for the graph. Defaults to the Three.js renderer.
+   */
+  renderEngine?: RenderEngine;
+
+  /**
+   * Additional cosmos.gl configuration when renderEngine is "cosmos".
+   */
+  cosmosConfig?: CosmosConfig;
 
   /**
    * Type of camera interaction.
@@ -89,23 +104,61 @@ export interface GraphCanvasProps extends Omit<GraphSceneProps, 'theme'> {
   aggregateEdges?: boolean;
 }
 
-export type GraphCanvasRef = Omit<GraphSceneRef, 'graph' | 'renderScene'> &
-  Omit<CameraControlsRef, 'controls'> & {
-    /**
-     * Get the graph object.
-     */
-    getGraph: () => Graph;
+export interface BaseGraphCanvasRef
+  extends Omit<GraphSceneRef, 'graph' | 'renderScene'> {
+  /**
+   * Get the graph object.
+   */
+  getGraph: () => Graph;
 
-    /**
-     * Get the camera controls.
-     */
-    getControls: () => ThreeCameraControls;
+  /**
+   * Export the canvas as a data URL.
+   */
+  exportCanvas: () => string;
 
-    /**
-     * Export the canvas as a data URL.
-     */
-    exportCanvas: () => string;
-  };
+  /**
+   * Zoom in on the graph.
+   */
+  zoomIn: () => void;
+
+  /**
+   * Zoom out on the graph.
+   */
+  zoomOut: () => void;
+
+  /**
+   * Reset controls to the initial graph view.
+   */
+  resetControls: (animated?: boolean) => void;
+
+  /**
+   * Freeze graph interactions.
+   */
+  freeze: () => void;
+
+  /**
+   * Unfreeze graph interactions.
+   */
+  unFreeze: () => void;
+}
+
+export interface ThreeGraphCanvasRef
+  extends BaseGraphCanvasRef,
+    Omit<CameraControlsRef, 'controls'> {
+  /**
+   * Get the camera controls.
+   */
+  getControls: () => ThreeCameraControls;
+}
+
+export type GraphCanvasRef = ThreeGraphCanvasRef;
+
+export interface CosmosGraphCanvasRef extends BaseGraphCanvasRef {
+  /**
+   * Get the cosmos.gl graph renderer.
+   */
+  getCosmosGraph: () => CosmosGraph | undefined;
+}
 
 const GL_DEFAULTS = {
   alpha: true,
@@ -120,7 +173,7 @@ const CAMERA_DEFAULTS: any = {
   fov: 10
 };
 
-export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
+const ThreeGraphCanvas = forwardRef<ThreeGraphCanvasRef, GraphCanvasProps>(
   (
     {
       cameraMode = 'pan',
@@ -146,10 +199,15 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
       onLasso,
       onLassoEnd,
       aggregateEdges,
+      renderEngine,
+      cosmosConfig,
       ...rest
     },
-    ref: Ref<GraphCanvasRef>
+    ref: Ref<ThreeGraphCanvasRef>
   ) => {
+    void renderEngine;
+    void cosmosConfig;
+
     const rendererRef = useRef<GraphSceneRef | null>(null);
     const controlsRef = useRef<CameraControlsRef | null>(null);
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -294,4 +352,16 @@ export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
       </div>
     );
   }
+);
+
+export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
+  (props, ref) =>
+    props.renderEngine === 'cosmos' ? (
+      <CosmosGraphCanvas
+        ref={ref as unknown as Ref<CosmosGraphCanvasRef>}
+        {...props}
+      />
+    ) : (
+      <ThreeGraphCanvas ref={ref as Ref<ThreeGraphCanvasRef>} {...props} />
+    )
 );

--- a/src/GraphCanvas/cosmos.ts
+++ b/src/GraphCanvas/cosmos.ts
@@ -1,0 +1,348 @@
+import type { Graph as CosmosGraph } from '@cosmos.gl/graph';
+import type { GraphConfigInterface } from '@cosmos.gl/graph/dist/config';
+import type Graph from 'graphology';
+import { Color, type ColorRepresentation } from 'three';
+
+import { getVisibleEntities } from '../collapse';
+import type { LayoutOverrides, LayoutTypes } from '../layout';
+import { layoutProvider } from '../layout';
+import { tick } from '../layout/layoutUtils';
+import type { SizingType } from '../sizing';
+import type { Theme } from '../themes';
+import type {
+  GraphEdge,
+  GraphNode,
+  InternalGraphEdge,
+  InternalGraphNode
+} from '../types';
+import { aggregateEdges as aggregateEdgesUtil } from '../utils/aggregateEdges';
+import { buildGraph, transformGraph } from '../utils/graph';
+import { getEdgeRenderStyle, getNodeRenderStyle } from '../utils/renderStyles';
+import type { LabelVisibilityType } from '../utils/visibility';
+
+export interface CosmosConfig extends Partial<GraphConfigInterface> {
+  /**
+   * Maximum number of DOM labels rendered by the cosmos renderer.
+   */
+  labelMaxCount?: number;
+
+  /**
+   * Minimum interval, in milliseconds, between cosmos label overlay updates.
+   */
+  labelUpdateInterval?: number;
+}
+
+export interface PreparedCosmosGraph {
+  graph: Graph;
+  nodes: InternalGraphNode[];
+  edges: InternalGraphEdge[];
+  nodeIndexById: Map<string, number>;
+}
+
+export interface PrepareCosmosGraphInput {
+  graph: Graph;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  aggregateEdges?: boolean;
+  collapsedNodeIds?: string[];
+  clusterAttribute?: string;
+  defaultNodeSize?: number;
+  labelType?: LabelVisibilityType;
+  layoutOverrides?: LayoutOverrides;
+  layoutType?: LayoutTypes;
+  maxNodeSize?: number;
+  minNodeSize?: number;
+  sizingAttribute?: string;
+  sizingType?: SizingType;
+}
+
+export interface BuildCosmosConfigInput {
+  config?: CosmosConfig;
+  defaultNodeSize?: number;
+  disabled?: boolean;
+  draggable?: boolean;
+  edgeArrowPosition?: 'none' | 'mid' | 'end';
+  edgeInterpolation?: 'linear' | 'curved';
+  onBackgroundClick?: (event: MouseEvent) => void;
+  onLinkClick?: GraphConfigInterface['onLinkClick'];
+  onLinkMouseOut?: GraphConfigInterface['onLinkMouseOut'];
+  onLinkMouseOver?: GraphConfigInterface['onLinkMouseOver'];
+  onPointDragEnd?: GraphConfigInterface['onDragEnd'];
+  onPointClick?: GraphConfigInterface['onPointClick'];
+  onPointMouseOut?: GraphConfigInterface['onPointMouseOut'];
+  onPointMouseOver?: GraphConfigInterface['onPointMouseOver'];
+  theme: Theme;
+}
+
+export interface BuildCosmosBuffersInput {
+  activeEdgeIds?: Set<string>;
+  activeNodeIds?: Set<string>;
+  colorActiveEdgeIds?: Set<string>;
+  defaultNodeSize?: number;
+  edgeArrowPosition?: 'none' | 'mid' | 'end';
+  hasSelections?: boolean;
+  preparedGraph: PreparedCosmosGraph;
+  selectedIds?: Set<string>;
+  theme: Theme;
+}
+
+export interface CosmosBuffers {
+  linkArrows: boolean[];
+  linkColors: Float32Array;
+  links: Float32Array;
+  linkWidths: Float32Array;
+  pointColors: Float32Array;
+  pointPositions: Float32Array;
+  pointSizes: Float32Array;
+}
+
+export const applyCosmosBuffers = (
+  graph: CosmosGraph,
+  buffers: CosmosBuffers,
+  animated?: boolean
+) => {
+  graph.setPointPositions(buffers.pointPositions, true);
+  graph.setPointColors(buffers.pointColors);
+  graph.setPointSizes(buffers.pointSizes);
+  graph.setLinks(buffers.links);
+  graph.setLinkColors(buffers.linkColors);
+  graph.setLinkWidths(buffers.linkWidths);
+  graph.setLinkArrows(buffers.linkArrows);
+  graph.render(animated ? undefined : 0);
+};
+
+export const toHexColor = (
+  color: ColorRepresentation | undefined,
+  fallback: string
+): string => {
+  if (!color) {
+    return fallback;
+  }
+
+  return `#${new Color(color).getHexString()}`;
+};
+
+const setRgba = (
+  target: Float32Array,
+  offset: number,
+  color: ColorRepresentation,
+  opacity: number
+) => {
+  const parsed = new Color(color);
+  target[offset] = parsed.r;
+  target[offset + 1] = parsed.g;
+  target[offset + 2] = parsed.b;
+  target[offset + 3] = opacity;
+};
+
+const getCosmosGraphConfig = (
+  config?: CosmosConfig
+): Partial<GraphConfigInterface> => {
+  if (!config) {
+    return {};
+  }
+
+  const { labelMaxCount, labelUpdateInterval, ...graphConfig } = config;
+  void labelMaxCount;
+  void labelUpdateInterval;
+
+  return graphConfig;
+};
+
+export const buildCosmosConfig = ({
+  config,
+  defaultNodeSize,
+  disabled,
+  draggable,
+  edgeArrowPosition = 'end',
+  edgeInterpolation = 'linear',
+  onBackgroundClick,
+  onLinkClick,
+  onLinkMouseOut,
+  onLinkMouseOver,
+  onPointDragEnd,
+  onPointClick,
+  onPointMouseOut,
+  onPointMouseOver,
+  theme
+}: BuildCosmosConfigInput): CosmosConfig => ({
+  backgroundColor: toHexColor(theme.canvas?.background, '#fff'),
+  pointDefaultColor: toHexColor(theme.node.fill, '#7CA0AB'),
+  pointDefaultSize: defaultNodeSize,
+  pointOpacity: 1,
+  linkDefaultColor: toHexColor(theme.edge.fill, '#D8E6EA'),
+  linkDefaultWidth: 1,
+  linkOpacity: 1,
+  linkDefaultArrows: edgeArrowPosition !== 'none',
+  linkVisibilityMinTransparency: 1,
+  curvedLinks: edgeInterpolation === 'curved',
+  enableDrag: Boolean(draggable && !disabled),
+  enableZoom: !disabled,
+  fitViewOnInit: true,
+  fitViewDelay: 250,
+  fitViewPadding: 0.1,
+  hoveredPointCursor: onPointClick && !disabled ? 'pointer' : 'auto',
+  hoveredLinkCursor: onLinkClick && !disabled ? 'pointer' : 'auto',
+  renderHoveredPointRing: true,
+  hoveredPointRingColor: toHexColor(theme.node.activeFill, '#1DE9AC'),
+  focusedPointRingColor: toHexColor(theme.node.activeFill, '#1DE9AC'),
+  enableSimulation: false,
+  rescalePositions: false,
+  attribution: '',
+  onBackgroundClick,
+  onPointClick,
+  onPointMouseOver,
+  onPointMouseOut,
+  onLinkClick,
+  onLinkMouseOver,
+  onLinkMouseOut,
+  onDragEnd: onPointDragEnd,
+  ...getCosmosGraphConfig(config)
+});
+
+export const prepareCosmosGraph = async ({
+  graph,
+  nodes,
+  edges,
+  aggregateEdges,
+  collapsedNodeIds = [],
+  clusterAttribute,
+  defaultNodeSize,
+  labelType,
+  layoutOverrides,
+  layoutType,
+  maxNodeSize,
+  minNodeSize,
+  sizingAttribute,
+  sizingType
+}: PrepareCosmosGraphInput): Promise<PreparedCosmosGraph> => {
+  const { visibleEdges, visibleNodes } = getVisibleEntities({
+    collapsedIds: collapsedNodeIds,
+    nodes,
+    edges
+  });
+
+  if (
+    clusterAttribute &&
+    !(layoutType === 'forceDirected2d' || layoutType === 'forceDirected3d')
+  ) {
+    throw new Error(
+      'Clustering is only supported for the force directed layouts.'
+    );
+  }
+
+  buildGraph(graph, visibleNodes, visibleEdges);
+
+  const layout = layoutProvider({
+    ...layoutOverrides,
+    type: layoutType,
+    graph,
+    drags: {},
+    clusters: new Map(),
+    clusterAttribute
+  });
+
+  await tick(layout);
+
+  const result = transformGraph({
+    graph,
+    layout,
+    sizingType,
+    labelType,
+    sizingAttribute,
+    maxNodeSize,
+    minNodeSize,
+    defaultNodeSize,
+    clusterAttribute
+  });
+
+  const renderedEdges = aggregateEdges
+    ? aggregateEdgesUtil(graph, labelType)
+    : result.edges;
+
+  return {
+    graph,
+    nodes: result.nodes,
+    edges: renderedEdges,
+    nodeIndexById: new Map(result.nodes.map((node, index) => [node.id, index]))
+  };
+};
+
+export const buildCosmosBuffers = ({
+  activeEdgeIds = new Set(),
+  activeNodeIds = new Set(),
+  colorActiveEdgeIds = activeEdgeIds,
+  defaultNodeSize,
+  edgeArrowPosition = 'end',
+  hasSelections,
+  preparedGraph,
+  selectedIds = new Set(),
+  theme
+}: BuildCosmosBuffersInput): CosmosBuffers => {
+  const { nodes, edges, nodeIndexById } = preparedGraph;
+  const pointPositions = new Float32Array(nodes.length * 2);
+  const pointColors = new Float32Array(nodes.length * 4);
+  const pointSizes = new Float32Array(nodes.length);
+
+  nodes.forEach((node, index) => {
+    const positionOffset = index * 2;
+    pointPositions[positionOffset] = node.position.x;
+    pointPositions[positionOffset + 1] = node.position.y;
+
+    const active = activeNodeIds.has(node.id) || selectedIds.has(node.id);
+    const style = getNodeRenderStyle({
+      node,
+      theme,
+      active,
+      hasSelections
+    });
+
+    setRgba(pointColors, index * 4, style.color, style.opacity);
+    pointSizes[index] = node.size ?? defaultNodeSize;
+  });
+
+  const links: number[] = [];
+  const renderedEdges: InternalGraphEdge[] = [];
+
+  edges.forEach(edge => {
+    const sourceIndex = nodeIndexById.get(edge.source);
+    const targetIndex = nodeIndexById.get(edge.target);
+
+    if (sourceIndex !== undefined && targetIndex !== undefined) {
+      links.push(sourceIndex, targetIndex);
+      renderedEdges.push(edge);
+    }
+  });
+
+  const linkColors = new Float32Array(renderedEdges.length * 4);
+  const linkWidths = new Float32Array(renderedEdges.length);
+  const linkArrows = renderedEdges.map(
+    edge => (edge.arrowPlacement ?? edgeArrowPosition) !== 'none'
+  );
+
+  renderedEdges.forEach((edge, index) => {
+    const selected = selectedIds.has(edge.id);
+    const active = activeEdgeIds.has(edge.id);
+    const colorActive = selected || active || colorActiveEdgeIds.has(edge.id);
+    const style = getEdgeRenderStyle({
+      edge,
+      theme,
+      active: selected || active,
+      colorActive,
+      hasSelections
+    });
+
+    setRgba(linkColors, index * 4, style.color, style.opacity);
+    linkWidths[index] = edge.size ?? 1;
+  });
+
+  return {
+    linkArrows,
+    linkColors,
+    links: new Float32Array(links),
+    linkWidths,
+    pointColors,
+    pointPositions,
+    pointSizes
+  };
+};

--- a/src/GraphCanvas/index.ts
+++ b/src/GraphCanvas/index.ts
@@ -1,9 +1,13 @@
+export type { CosmosConfig } from './cosmos';
 export type {
   BaseGraphCanvasRef,
+  CosmosGraphCanvasProps,
   CosmosGraphCanvasRef,
+  GraphCanvasComponent,
   GraphCanvasProps,
   GraphCanvasRef,
   RenderEngine,
+  ThreeGraphCanvasProps,
   ThreeGraphCanvasRef
 } from './GraphCanvas';
 export { GraphCanvas } from './GraphCanvas';

--- a/src/GraphCanvas/index.ts
+++ b/src/GraphCanvas/index.ts
@@ -1,2 +1,9 @@
-export type { GraphCanvasProps, GraphCanvasRef } from './GraphCanvas';
+export type {
+  BaseGraphCanvasRef,
+  CosmosGraphCanvasRef,
+  GraphCanvasProps,
+  GraphCanvasRef,
+  RenderEngine,
+  ThreeGraphCanvasRef
+} from './GraphCanvas';
 export { GraphCanvas } from './GraphCanvas';

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -18,6 +18,7 @@ import {
   getVector
 } from '../utils';
 import { calculateSubLabelOffset, getSelfLoopCurve } from '../utils/position';
+import { getEdgeRenderStyle } from '../utils/renderStyles';
 import { useHoverIntent } from '../utils/useHoverIntent';
 import type { EdgeArrowPosition } from './Arrow';
 import { Arrow } from './Arrow';
@@ -258,12 +259,13 @@ export const Edge: FC<EdgeProps> = ({
   const hasSelections = useStore(state => state.selections?.length);
   const isActive = useStore(state => state.actives?.includes(id));
   const isActiveState = active || isActive || isSelected;
-
-  const selectionOpacity = hasSelections
-    ? isSelected || isActive
-      ? theme.edge.selectedOpacity
-      : theme.edge.inactiveOpacity
-    : theme.edge.opacity;
+  const { color, opacity: selectionOpacity } = getEdgeRenderStyle({
+    edge,
+    theme,
+    active: isSelected || isActive,
+    colorActive: isActiveState,
+    hasSelections: Boolean(hasSelections)
+  });
 
   // Calculate subLabel position based on edge orientation and subLabelPlacement
   const subLabelOffset = useMemo(() => {
@@ -491,9 +493,7 @@ export const Edge: FC<EdgeProps> = ({
           curve={selfLoopCurve}
           size={size}
           animated={animated}
-          color={
-            isActiveState ? theme.edge.activeFill : fill || theme.edge.fill
-          }
+          color={color}
           opacity={selectionOpacity}
           onClick={event => {
             if (!disabled) {
@@ -513,9 +513,7 @@ export const Edge: FC<EdgeProps> = ({
         <Line
           curveOffset={curveOffset}
           animated={animated}
-          color={
-            isActiveState ? theme.edge.activeFill : fill || theme.edge.fill
-          }
+          color={color}
           curve={curve}
           curved={curved}
           dashed={dashed}

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -15,6 +15,7 @@ import type {
   NodeRenderer
 } from '../types';
 import { animationConfig } from '../utils';
+import { getNodeRenderStyle } from '../utils/renderStyles';
 import { useDrag } from '../utils/useDrag';
 import { useHoverIntent } from '../utils/useHoverIntent';
 import { Label } from './Label';
@@ -165,12 +166,6 @@ export const Node: FC<NodeProps> = ({
 
   const shouldHighlight = active || isSelected || isActive;
 
-  const selectionOpacity = hasSelections
-    ? shouldHighlight
-      ? theme.node.selectedOpacity
-      : theme.node.inactiveOpacity
-    : theme.node.opacity;
-
   const canCollapse = useMemo(() => {
     // If the node has outgoing edges, it can collapse via context menu
     const outboundLinks = edges.filter(l => l.source === id);
@@ -237,9 +232,13 @@ export const Node: FC<NodeProps> = ({
   useCursor(isDraggingCurrent, 'grabbing');
 
   const combinedActiveState = shouldHighlight || isDraggingCurrent;
-  const color = combinedActiveState
-    ? theme.node.activeFill
-    : node.fill || theme.node.fill;
+  const { color, opacity: selectionOpacity } = getNodeRenderStyle({
+    node,
+    theme,
+    active: shouldHighlight,
+    colorActive: combinedActiveState,
+    hasSelections
+  });
 
   const { pointerOver, pointerOut } = useHoverIntent({
     disabled: disabled || isDraggingCurrent,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,5 +7,6 @@ export * from './graph';
 export * from './layout';
 export * from './paths';
 export * from './position';
+export * from './renderStyles';
 export * from './textMeasurement';
 export * from './visibility';

--- a/src/utils/renderStyles.ts
+++ b/src/utils/renderStyles.ts
@@ -1,0 +1,79 @@
+import type { ColorRepresentation } from 'three';
+
+import type { Theme } from '../themes';
+import type { InternalGraphEdge, InternalGraphNode } from '../types';
+
+export interface RenderStyle {
+  color: ColorRepresentation;
+  opacity: number;
+}
+
+export interface NodeRenderStyleInput {
+  node: InternalGraphNode;
+  theme: Theme;
+  active?: boolean;
+  colorActive?: boolean;
+  hasSelections?: boolean;
+}
+
+export interface EdgeRenderStyleInput {
+  edge: InternalGraphEdge;
+  theme: Theme;
+  active?: boolean;
+  colorActive?: boolean;
+  hasSelections?: boolean;
+}
+
+const getSelectionOpacity = ({
+  active,
+  baseOpacity,
+  hasSelections,
+  inactiveOpacity,
+  selectedOpacity
+}: {
+  active?: boolean;
+  baseOpacity: number;
+  hasSelections?: boolean;
+  inactiveOpacity: number;
+  selectedOpacity: number;
+}) => {
+  if (!hasSelections) {
+    return baseOpacity;
+  }
+
+  return active ? selectedOpacity : inactiveOpacity;
+};
+
+export const getNodeRenderStyle = ({
+  node,
+  theme,
+  active,
+  colorActive = active,
+  hasSelections
+}: NodeRenderStyleInput): RenderStyle => ({
+  color: colorActive ? theme.node.activeFill : node.fill || theme.node.fill,
+  opacity: getSelectionOpacity({
+    active,
+    baseOpacity: theme.node.opacity,
+    hasSelections,
+    inactiveOpacity: theme.node.inactiveOpacity,
+    selectedOpacity: theme.node.selectedOpacity
+  })
+});
+
+export const getEdgeRenderStyle = ({
+  edge,
+  theme,
+  active,
+  colorActive = active,
+  hasSelections
+}: EdgeRenderStyleInput): RenderStyle => ({
+  color: colorActive ? theme.edge.activeFill : edge.fill || theme.edge.fill,
+  opacity: getSelectionOpacity({
+    active,
+    baseOpacity: theme.edge.opacity,
+    hasSelections,
+    inactiveOpacity: theme.edge.inactiveOpacity,
+    selectedOpacity: theme.edge.selectedOpacity
+  })
+});

--- a/stories/demos/LargeGraph.story.tsx
+++ b/stories/demos/LargeGraph.story.tsx
@@ -28,7 +28,6 @@ const GROUP_COUNT = 16;
 const GROUP_RADIUS = 2800;
 const NODE_SPACING = 34;
 const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
-const LABEL_MARGIN = 24;
 
 const COLORS = [
   '#2563eb',
@@ -51,23 +50,8 @@ const graphButtonStyle = (active: boolean): React.CSSProperties => ({
   background: active ? '#f9fafb' : 'rgba(255, 255, 255, 0.14)'
 });
 
-interface LabelCandidate {
-  id: string;
-  label: string;
-  position: [number, number];
-  priority: number;
-}
-
-interface ScreenLabel {
-  id: string;
-  label: string;
-  x: number;
-  y: number;
-}
-
 interface StoryStats {
   fps: number;
-  labels: ScreenLabel[];
   zoom: number;
 }
 
@@ -77,7 +61,6 @@ interface GraphOverlayProps {
     (GraphCanvasRef & Partial<CosmosGraphCanvasRef>) | null
   >;
   interactionLabel: string;
-  labelCandidates: LabelCandidate[];
   nodes: GraphNode[];
   renderEngine: RenderEngine;
   setRenderEngine: (engine: RenderEngine) => void;
@@ -89,20 +72,18 @@ interface NodeConnections {
   neighborCount: number;
 }
 
-const EMPTY_LABELS: ScreenLabel[] = [];
 const EMPTY_IDS: string[] = [];
 const COSMOS_CONFIG = {
   fitViewDelay: 0,
   fitViewDuration: 0,
+  labelMaxCount: GROUP_COUNT,
+  labelUpdateInterval: 50,
   linkOpacity: 1,
   linkVisibilityMinTransparency: 1,
   linkWidthScale: 2.4,
-  pointSamplingDistance: 120,
+  pointSamplingDistance: 260,
   scaleLinksOnZoom: true
 };
-type CosmosGraphInstance = NonNullable<
-  ReturnType<CosmosGraphCanvasRef['getCosmosGraph']>
->;
 
 const getNodeLayoutPosition = (index: number, data?: GraphNode['data']) => {
   const group = index % GROUP_COUNT;
@@ -125,11 +106,11 @@ function createLargeGraph() {
   const nodes: GraphNode[] = Array.from({ length: NODE_COUNT }, (_, index) => {
     const group = index % GROUP_COUNT;
     const localIndex = Math.floor(index / GROUP_COUNT);
-    const isLabelAnchor = localIndex % 60 === 0;
+    const isLabelAnchor = localIndex === 0;
 
     return {
       id: `n-${index}`,
-      label: isLabelAnchor ? `Group ${group} / ${localIndex}` : `Node ${index}`,
+      label: isLabelAnchor ? `Group ${group}` : undefined,
       fill: COLORS[group % COLORS.length],
       size: isLabelAnchor ? 14 : undefined,
       data: {
@@ -215,93 +196,14 @@ const largeGraphLayout = {
   }
 } as LayoutFactoryProps;
 
-const createLabelCandidates = (nodes: GraphNode[]): LabelCandidate[] =>
-  nodes.reduce<LabelCandidate[]>((labels, node, index) => {
-    const localIndex = Math.floor(index / GROUP_COUNT);
-    const shouldLabel = localIndex === 0 || localIndex % 60 === 0;
-
-    if (!shouldLabel) {
-      return labels;
-    }
-
-    const position = getNodeLayoutPosition(index);
-
-    labels.push({
-      id: node.id,
-      label: node.label ?? node.id,
-      position: [position.x, position.y],
-      priority: localIndex === 0 ? 0 : localIndex % 120 === 0 ? 1 : 2
-    });
-
-    return labels;
-  }, []);
-
-const getCosmosLabels = (
-  graph: CosmosGraphInstance,
-  labelCandidates: LabelCandidate[]
-): ScreenLabel[] => {
-  const zoom = graph.getZoomLevel();
-  const maxPriority = zoom > 3 ? 2 : zoom > 1.5 ? 1 : 0;
-  const maxLabels = zoom > 3 ? 64 : zoom > 1.5 ? 36 : 16;
-  const labels: ScreenLabel[] = [];
-
-  for (const candidate of labelCandidates) {
-    if (candidate.priority > maxPriority) {
-      continue;
-    }
-
-    const [x, y] = graph.spaceToScreenPosition(candidate.position);
-
-    if (
-      x < LABEL_MARGIN ||
-      y < LABEL_MARGIN ||
-      x > window.innerWidth - LABEL_MARGIN ||
-      y > window.innerHeight - LABEL_MARGIN
-    ) {
-      continue;
-    }
-
-    labels.push({
-      id: candidate.id,
-      label: candidate.label,
-      x,
-      y
-    });
-
-    if (labels.length >= maxLabels) {
-      break;
-    }
-  }
-
-  return labels;
-};
-
-const areLabelsEqual = (a: ScreenLabel[], b: ScreenLabel[]) => {
-  if (a.length !== b.length) {
-    return false;
-  }
-
-  return a.every((label, index) => {
-    const next = b[index];
-    return (
-      label.id === next.id &&
-      label.label === next.label &&
-      Math.abs(label.x - next.x) < 1 &&
-      Math.abs(label.y - next.y) < 1
-    );
-  });
-};
-
 const useStoryStats = (
   renderEngine: RenderEngine,
   graphRef: React.RefObject<
     (GraphCanvasRef & Partial<CosmosGraphCanvasRef>) | null
-  >,
-  labelCandidates: LabelCandidate[]
+  >
 ) => {
   const [stats, setStats] = useState<StoryStats>({
     fps: 0,
-    labels: EMPTY_LABELS,
     zoom: 1
   });
 
@@ -313,7 +215,6 @@ const useStoryStats = (
     let lastLabelUpdate = lastFpsUpdate;
     let lastStats: StoryStats = {
       fps,
-      labels: renderEngine === 'cosmos' ? [] : EMPTY_LABELS,
       zoom: 1
     };
 
@@ -335,16 +236,12 @@ const useStoryStats = (
 
         const nextStats = {
           fps,
-          labels: cosmosGraph
-            ? getCosmosLabels(cosmosGraph, labelCandidates)
-            : EMPTY_LABELS,
           zoom: cosmosGraph?.getZoomLevel() ?? 1
         };
 
         if (
           nextStats.fps !== lastStats.fps ||
-          Math.abs(nextStats.zoom - lastStats.zoom) >= 0.01 ||
-          !areLabelsEqual(nextStats.labels, lastStats.labels)
+          Math.abs(nextStats.zoom - lastStats.zoom) >= 0.01
         ) {
           lastStats = nextStats;
           setStats(nextStats);
@@ -368,7 +265,7 @@ const useStoryStats = (
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [graphRef, labelCandidates, renderEngine]);
+  }, [graphRef, renderEngine]);
 
   return stats;
 };
@@ -377,41 +274,14 @@ const GraphOverlay = ({
   edges,
   graphRef,
   interactionLabel,
-  labelCandidates,
   nodes,
   renderEngine,
   setRenderEngine
 }: GraphOverlayProps) => {
-  const stats = useStoryStats(renderEngine, graphRef, labelCandidates);
+  const stats = useStoryStats(renderEngine, graphRef);
 
   return (
     <>
-      {renderEngine === 'cosmos' &&
-        stats.labels.map(label => (
-          <div
-            key={label.id}
-            style={{
-              color: '#2A6475',
-              fontSize: 12,
-              fontWeight: 600,
-              left: label.x,
-              maxWidth: 140,
-              overflow: 'hidden',
-              pointerEvents: 'none',
-              position: 'absolute',
-              textAlign: 'center',
-              textOverflow: 'ellipsis',
-              textShadow:
-                '-1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff',
-              top: label.y,
-              transform: 'translate(-50%, -150%)',
-              whiteSpace: 'nowrap',
-              zIndex: 8
-            }}
-          >
-            {label.label}
-          </div>
-        ))}
       <div
         style={{
           alignItems: 'center',
@@ -467,7 +337,6 @@ export const RendererSwitch = () => {
   const [interactionLabel, setInteractionLabel] = useState('Ready');
   const { nodes, edges } = useMemo(createLargeGraph, []);
   const connectionMap = useMemo(() => createConnectionMap(edges), [edges]);
-  const labelCandidates = useMemo(() => createLabelCandidates(nodes), [nodes]);
   const actives = useMemo(
     () => (activeId ? [activeId] : EMPTY_IDS),
     [activeId]
@@ -562,7 +431,6 @@ export const RendererSwitch = () => {
         edges={edges}
         graphRef={graphRef}
         interactionLabel={interactionLabel}
-        labelCandidates={labelCandidates}
         nodes={nodes}
         renderEngine={renderEngine}
         setRenderEngine={setRenderEngine}

--- a/stories/demos/LargeGraph.story.tsx
+++ b/stories/demos/LargeGraph.story.tsx
@@ -1,0 +1,572 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import type {
+  CosmosGraphCanvasRef,
+  GraphCanvasRef,
+  GraphEdge,
+  GraphNode,
+  LayoutFactoryProps,
+  NodePositionArgs,
+  RenderEngine
+} from '../../src';
+import { GraphCanvas } from '../../src';
+
+export default {
+  title: 'Demos/Large Graph',
+  component: GraphCanvas
+};
+
+const NODE_COUNT = 5000;
+const EDGE_COUNT = 12000;
+const GROUP_COUNT = 16;
+const GROUP_RADIUS = 2800;
+const NODE_SPACING = 34;
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+const LABEL_MARGIN = 24;
+
+const COLORS = [
+  '#2563eb',
+  '#0891b2',
+  '#059669',
+  '#65a30d',
+  '#ca8a04',
+  '#dc2626',
+  '#be185d',
+  '#7c3aed'
+];
+
+const graphButtonStyle = (active: boolean): React.CSSProperties => ({
+  border: 0,
+  borderRadius: 3,
+  color: active ? '#111827' : '#e5e7eb',
+  cursor: active ? 'default' : 'pointer',
+  fontWeight: 600,
+  padding: '6px 10px',
+  background: active ? '#f9fafb' : 'rgba(255, 255, 255, 0.14)'
+});
+
+interface LabelCandidate {
+  id: string;
+  label: string;
+  position: [number, number];
+  priority: number;
+}
+
+interface ScreenLabel {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+}
+
+interface StoryStats {
+  fps: number;
+  labels: ScreenLabel[];
+  zoom: number;
+}
+
+interface GraphOverlayProps {
+  edges: GraphEdge[];
+  graphRef: React.RefObject<
+    (GraphCanvasRef & Partial<CosmosGraphCanvasRef>) | null
+  >;
+  interactionLabel: string;
+  labelCandidates: LabelCandidate[];
+  nodes: GraphNode[];
+  renderEngine: RenderEngine;
+  setRenderEngine: (engine: RenderEngine) => void;
+}
+
+interface NodeConnections {
+  edgeCount: number;
+  ids: string[];
+  neighborCount: number;
+}
+
+const EMPTY_LABELS: ScreenLabel[] = [];
+const EMPTY_IDS: string[] = [];
+const COSMOS_CONFIG = {
+  fitViewDelay: 0,
+  fitViewDuration: 0,
+  linkOpacity: 1,
+  linkVisibilityMinTransparency: 1,
+  linkWidthScale: 2.4,
+  pointSamplingDistance: 120,
+  scaleLinksOnZoom: true
+};
+type CosmosGraphInstance = NonNullable<
+  ReturnType<CosmosGraphCanvasRef['getCosmosGraph']>
+>;
+
+const getNodeLayoutPosition = (index: number, data?: GraphNode['data']) => {
+  const group = index % GROUP_COUNT;
+  const groupAngle = (group / GROUP_COUNT) * Math.PI * 2;
+  const groupCenterX = Math.cos(groupAngle) * GROUP_RADIUS;
+  const groupCenterY = Math.sin(groupAngle) * GROUP_RADIUS;
+  const localIndex = Math.floor(index / GROUP_COUNT);
+  const localRadius = NODE_SPACING * Math.sqrt(localIndex);
+  const localAngle = localIndex * GOLDEN_ANGLE;
+
+  return {
+    x: groupCenterX + Math.cos(localAngle) * localRadius,
+    y: groupCenterY + Math.sin(localAngle) * localRadius,
+    z: 1,
+    data
+  };
+};
+
+function createLargeGraph() {
+  const nodes: GraphNode[] = Array.from({ length: NODE_COUNT }, (_, index) => {
+    const group = index % GROUP_COUNT;
+    const localIndex = Math.floor(index / GROUP_COUNT);
+    const isLabelAnchor = localIndex % 60 === 0;
+
+    return {
+      id: `n-${index}`,
+      label: isLabelAnchor ? `Group ${group} / ${localIndex}` : `Node ${index}`,
+      fill: COLORS[group % COLORS.length],
+      size: isLabelAnchor ? 14 : undefined,
+      data: {
+        group,
+        weight: isLabelAnchor ? 18 : 1 + ((index * 13) % 9)
+      }
+    };
+  });
+
+  const edges: GraphEdge[] = Array.from({ length: EDGE_COUNT }, (_, index) => {
+    const source = index % NODE_COUNT;
+    const sameGroupTarget =
+      (source + GROUP_COUNT * (1 + ((index * 7) % 5))) % NODE_COUNT;
+    const crossGroupTarget =
+      (source + 1 + ((index * 97) % (NODE_COUNT - 1))) % NODE_COUNT;
+    const target = index % 8 === 0 ? crossGroupTarget : sameGroupTarget;
+
+    return {
+      id: `e-${index}`,
+      fill: index % 8 === 0 ? '#334155' : '#475569',
+      size: index % 8 === 0 ? 1.8 : 2.2,
+      source: `n-${source}`,
+      target: `n-${target}`
+    };
+  });
+
+  return { nodes, edges };
+}
+
+const areIdsEqual = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((id, index) => id === b[index]);
+
+const createConnectionMap = (edges: GraphEdge[]) => {
+  const connections = new Map<
+    string,
+    {
+      edgeIds: Set<string>;
+      neighborIds: Set<string>;
+    }
+  >();
+
+  const getConnections = (id: string) => {
+    let nodeConnections = connections.get(id);
+
+    if (!nodeConnections) {
+      nodeConnections = {
+        edgeIds: new Set(),
+        neighborIds: new Set()
+      };
+      connections.set(id, nodeConnections);
+    }
+
+    return nodeConnections;
+  };
+
+  edges.forEach(edge => {
+    const sourceConnections = getConnections(edge.source);
+    const targetConnections = getConnections(edge.target);
+
+    sourceConnections.edgeIds.add(edge.id);
+    sourceConnections.neighborIds.add(edge.target);
+    targetConnections.edgeIds.add(edge.id);
+    targetConnections.neighborIds.add(edge.source);
+  });
+
+  const result = new Map<string, NodeConnections>();
+
+  connections.forEach(({ edgeIds, neighborIds }, nodeId) => {
+    result.set(nodeId, {
+      edgeCount: edgeIds.size,
+      ids: [nodeId, ...neighborIds, ...edgeIds],
+      neighborCount: neighborIds.size
+    });
+  });
+
+  return result;
+};
+
+const largeGraphLayout = {
+  getNodePosition: (id: string, { nodes }: NodePositionArgs) => {
+    const index = Number(id.replace('n-', ''));
+    return getNodeLayoutPosition(index, nodes[index]?.data);
+  }
+} as LayoutFactoryProps;
+
+const createLabelCandidates = (nodes: GraphNode[]): LabelCandidate[] =>
+  nodes.reduce<LabelCandidate[]>((labels, node, index) => {
+    const localIndex = Math.floor(index / GROUP_COUNT);
+    const shouldLabel = localIndex === 0 || localIndex % 60 === 0;
+
+    if (!shouldLabel) {
+      return labels;
+    }
+
+    const position = getNodeLayoutPosition(index);
+
+    labels.push({
+      id: node.id,
+      label: node.label ?? node.id,
+      position: [position.x, position.y],
+      priority: localIndex === 0 ? 0 : localIndex % 120 === 0 ? 1 : 2
+    });
+
+    return labels;
+  }, []);
+
+const getCosmosLabels = (
+  graph: CosmosGraphInstance,
+  labelCandidates: LabelCandidate[]
+): ScreenLabel[] => {
+  const zoom = graph.getZoomLevel();
+  const maxPriority = zoom > 3 ? 2 : zoom > 1.5 ? 1 : 0;
+  const maxLabels = zoom > 3 ? 64 : zoom > 1.5 ? 36 : 16;
+  const labels: ScreenLabel[] = [];
+
+  for (const candidate of labelCandidates) {
+    if (candidate.priority > maxPriority) {
+      continue;
+    }
+
+    const [x, y] = graph.spaceToScreenPosition(candidate.position);
+
+    if (
+      x < LABEL_MARGIN ||
+      y < LABEL_MARGIN ||
+      x > window.innerWidth - LABEL_MARGIN ||
+      y > window.innerHeight - LABEL_MARGIN
+    ) {
+      continue;
+    }
+
+    labels.push({
+      id: candidate.id,
+      label: candidate.label,
+      x,
+      y
+    });
+
+    if (labels.length >= maxLabels) {
+      break;
+    }
+  }
+
+  return labels;
+};
+
+const areLabelsEqual = (a: ScreenLabel[], b: ScreenLabel[]) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((label, index) => {
+    const next = b[index];
+    return (
+      label.id === next.id &&
+      label.label === next.label &&
+      Math.abs(label.x - next.x) < 1 &&
+      Math.abs(label.y - next.y) < 1
+    );
+  });
+};
+
+const useStoryStats = (
+  renderEngine: RenderEngine,
+  graphRef: React.RefObject<
+    (GraphCanvasRef & Partial<CosmosGraphCanvasRef>) | null
+  >,
+  labelCandidates: LabelCandidate[]
+) => {
+  const [stats, setStats] = useState<StoryStats>({
+    fps: 0,
+    labels: EMPTY_LABELS,
+    zoom: 1
+  });
+
+  useEffect(() => {
+    let frameId = 0;
+    let frames = 0;
+    let fps = 0;
+    let lastFpsUpdate = performance.now();
+    let lastLabelUpdate = lastFpsUpdate;
+    let lastStats: StoryStats = {
+      fps,
+      labels: renderEngine === 'cosmos' ? [] : EMPTY_LABELS,
+      zoom: 1
+    };
+
+    const update = (now: number) => {
+      frames += 1;
+
+      const shouldUpdateFps = now - lastFpsUpdate >= 500;
+      const shouldUpdateLabels =
+        renderEngine === 'cosmos' && now - lastLabelUpdate >= 50;
+
+      if (shouldUpdateFps || shouldUpdateLabels) {
+        const cosmosGraph =
+          renderEngine === 'cosmos'
+            ? graphRef.current?.getCosmosGraph?.()
+            : undefined;
+        if (shouldUpdateFps) {
+          fps = Math.round((frames * 1000) / (now - lastFpsUpdate));
+        }
+
+        const nextStats = {
+          fps,
+          labels: cosmosGraph
+            ? getCosmosLabels(cosmosGraph, labelCandidates)
+            : EMPTY_LABELS,
+          zoom: cosmosGraph?.getZoomLevel() ?? 1
+        };
+
+        if (
+          nextStats.fps !== lastStats.fps ||
+          Math.abs(nextStats.zoom - lastStats.zoom) >= 0.01 ||
+          !areLabelsEqual(nextStats.labels, lastStats.labels)
+        ) {
+          lastStats = nextStats;
+          setStats(nextStats);
+        }
+
+        if (shouldUpdateFps) {
+          frames = 0;
+          lastFpsUpdate = now;
+        }
+
+        if (shouldUpdateLabels) {
+          lastLabelUpdate = now;
+        }
+      }
+
+      frameId = requestAnimationFrame(update);
+    };
+
+    frameId = requestAnimationFrame(update);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [graphRef, labelCandidates, renderEngine]);
+
+  return stats;
+};
+
+const GraphOverlay = ({
+  edges,
+  graphRef,
+  interactionLabel,
+  labelCandidates,
+  nodes,
+  renderEngine,
+  setRenderEngine
+}: GraphOverlayProps) => {
+  const stats = useStoryStats(renderEngine, graphRef, labelCandidates);
+
+  return (
+    <>
+      {renderEngine === 'cosmos' &&
+        stats.labels.map(label => (
+          <div
+            key={label.id}
+            style={{
+              color: '#2A6475',
+              fontSize: 12,
+              fontWeight: 600,
+              left: label.x,
+              maxWidth: 140,
+              overflow: 'hidden',
+              pointerEvents: 'none',
+              position: 'absolute',
+              textAlign: 'center',
+              textOverflow: 'ellipsis',
+              textShadow:
+                '-1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff',
+              top: label.y,
+              transform: 'translate(-50%, -150%)',
+              whiteSpace: 'nowrap',
+              zIndex: 8
+            }}
+          >
+            {label.label}
+          </div>
+        ))}
+      <div
+        style={{
+          alignItems: 'center',
+          background: 'rgba(17, 24, 39, 0.88)',
+          borderRadius: 4,
+          color: '#f9fafb',
+          display: 'flex',
+          gap: 8,
+          padding: 8,
+          position: 'absolute',
+          right: 15,
+          top: 15,
+          zIndex: 9
+        }}
+      >
+        <button
+          type="button"
+          style={graphButtonStyle(renderEngine === 'three')}
+          onClick={() => setRenderEngine('three')}
+          disabled={renderEngine === 'three'}
+        >
+          Three.js
+        </button>
+        <button
+          type="button"
+          style={graphButtonStyle(renderEngine === 'cosmos')}
+          onClick={() => setRenderEngine('cosmos')}
+          disabled={renderEngine === 'cosmos'}
+        >
+          cosmos.gl
+        </button>
+        <span style={{ fontSize: 12 }}>
+          {nodes.length.toLocaleString()} nodes /{' '}
+          {edges.length.toLocaleString()} edges
+        </span>
+        <span style={{ fontSize: 12 }}>{stats.fps} FPS</span>
+        {renderEngine === 'cosmos' && (
+          <span style={{ fontSize: 12 }}>{stats.zoom.toFixed(2)}x zoom</span>
+        )}
+        <span style={{ fontSize: 12 }}>{interactionLabel}</span>
+      </div>
+    </>
+  );
+};
+
+export const RendererSwitch = () => {
+  const graphRef = useRef<
+    (GraphCanvasRef & Partial<CosmosGraphCanvasRef>) | null
+  >(null);
+  const [renderEngine, setRenderEngine] = useState<RenderEngine>('cosmos');
+  const [selectedIds, setSelectedIds] = useState<string[]>(EMPTY_IDS);
+  const [activeId, setActiveId] = useState<string | undefined>();
+  const [interactionLabel, setInteractionLabel] = useState('Ready');
+  const { nodes, edges } = useMemo(createLargeGraph, []);
+  const connectionMap = useMemo(() => createConnectionMap(edges), [edges]);
+  const labelCandidates = useMemo(() => createLabelCandidates(nodes), [nodes]);
+  const actives = useMemo(
+    () => (activeId ? [activeId] : EMPTY_IDS),
+    [activeId]
+  );
+
+  const updateInteraction = useCallback((label: string) => {
+    setInteractionLabel(current => (current === label ? current : label));
+  }, []);
+
+  const clearActive = useCallback(() => {
+    setActiveId(current => (current === undefined ? current : undefined));
+  }, []);
+
+  const handleCanvasClick = useCallback(() => {
+    setSelectedIds(current => (current.length ? EMPTY_IDS : current));
+    updateInteraction('Canvas');
+  }, [updateInteraction]);
+
+  const handleEdgeClick = useCallback(
+    (edge: GraphEdge) => {
+      const ids = [edge.source, edge.target, edge.id];
+      setSelectedIds(current => (areIdsEqual(current, ids) ? current : ids));
+      updateInteraction(`Edge ${edge.id}`);
+    },
+    [updateInteraction]
+  );
+
+  const handleEdgePointerOver = useCallback(
+    (edge: GraphEdge) => {
+      setActiveId(current => (current === edge.id ? current : edge.id));
+      updateInteraction(`Edge ${edge.id}`);
+    },
+    [updateInteraction]
+  );
+
+  const handleNodeClick = useCallback(
+    (node: GraphNode) => {
+      const connections = connectionMap.get(node.id);
+      const ids = connections?.ids ?? [node.id];
+
+      setSelectedIds(current => (areIdsEqual(current, ids) ? current : ids));
+      updateInteraction(
+        connections
+          ? `${node.label ?? node.id}: ${connections.edgeCount} edges, ${
+              connections.neighborCount
+            } neighbors`
+          : (node.label ?? node.id)
+      );
+    },
+    [connectionMap, updateInteraction]
+  );
+
+  const handleNodePointerOver = useCallback(
+    (node: GraphNode) => {
+      setActiveId(current => (current === node.id ? current : node.id));
+      updateInteraction(node.label ?? node.id);
+    },
+    [updateInteraction]
+  );
+
+  return (
+    <div style={{ inset: 0, overflow: 'hidden', position: 'absolute' }}>
+      <GraphCanvas
+        ref={graphRef}
+        key={renderEngine}
+        animated={false}
+        cosmosConfig={COSMOS_CONFIG}
+        defaultNodeSize={6}
+        disabled={false}
+        edgeArrowPosition="none"
+        edges={edges}
+        labelType="auto"
+        layoutOverrides={largeGraphLayout}
+        layoutType="custom"
+        maxNodeSize={16}
+        minNodeSize={3}
+        nodes={nodes}
+        actives={actives}
+        onCanvasClick={handleCanvasClick}
+        onEdgeClick={handleEdgeClick}
+        onEdgePointerOut={clearActive}
+        onEdgePointerOver={handleEdgePointerOver}
+        onNodeClick={handleNodeClick}
+        onNodePointerOut={clearActive}
+        onNodePointerOver={handleNodePointerOver}
+        renderEngine={renderEngine}
+        selections={selectedIds}
+        sizingAttribute="weight"
+        sizingType="attribute"
+      />
+      <GraphOverlay
+        edges={edges}
+        graphRef={graphRef}
+        interactionLabel={interactionLabel}
+        labelCandidates={labelCandidates}
+        nodes={nodes}
+        renderEngine={renderEngine}
+        setRenderEngine={setRenderEngine}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
As already mentioned in recent bug reports (#113), the framework's rendering performance for large graph networks is laggy and therefore not usable for graphs with multiple thousand nodes/edges. This stems from the three.js rendering engine, which doesn't use native WebGL rendering. Therefore, this feature introduces the implementation of the cosmos.gl renderer, which tends to be very fast.

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Slow rendering updates on large graphs cause navigation to become stuck and significant delays when interacting with the graph, making it unmanageable.


## What is the new behavior?
Fluent and fast interaction with GPU acceleration.
One video tells more than 1000 words:
<video src='https://github.com/user-attachments/assets/2d6ccfbf-d702-4c12-9d21-92ff7b7e7b62'/>

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```


The PR keeps the existing Three.js renderer as the default, so the current `GraphCanvas` usage remains unchanged.

The breaking consideration applies when consumers opt into the new `renderEngine="cosmos"` renderer. The cosmos renderer should use its own ref contract, `CosmosGraphCanvasRef`, instead of the existing `GraphCanvasRef`. It exposes `getControls()`, but this returns a cosmos-specific controls adapter, not direct Three.js camera controls.

Migration path:

- Existing Three.js/default usage requires no changes.
- Use `CosmosGraphCanvasRef` when rendering with `renderEngine="cosmos"`.
- Use the cosmos `getControls()` adapter for shared actions such as zooming, fitting, centering, freezing, and unfreezing.
- Be aware that some Three.js-specific features are not supported by the cosmos renderer yet, including edge lasso selection, custom renderers, children, cluster rendering/events, and direct Three.js controls access.
- Node lasso selection is supported for the cosmos renderer via `lassoType="node"` and `lassoType="all"`.

## Other information
A demo is already included inside the storybook, with a very large graph, so you can try it on your own.