### PR TITLE
perf: large-graph performance overhaul (O(1) store lookups, shared geometry, graphology-native collapse)

### DIFF
--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -201,6 +201,21 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
       edges: internalEdges as any
     });
   });
+  // Mirrors useGraph/useCollapse, which build the graph once per data change
+  // and reuse it across collapse/expand interactions.
+  const prebuiltCollapseGraph = buildGraph(
+    new Graph({ multi: true }),
+    internalNodes as any,
+    internalEdges as any
+  );
+  time('getVisibleEntities with reused graph (50 collapsed)', () => {
+    getVisibleEntities({
+      collapsedIds: ids.slice(0, 50),
+      nodes: internalNodes as any,
+      edges: internalEdges as any,
+      graph: prebuiltCollapseGraph
+    });
+  });
   time('collapse visibility filter — Array.includes [old]', () => {
     void internalNodes.filter(node => !hidden.includes(node.id));
   });

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -170,6 +170,39 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
     });
   });
 
+  // --- 3c. Collapse traversal primitives (collapse/utils.ts) ---
+  // Old code scanned the full edge list per node (edges.filter source/target)
+  // and used Array.includes for the hidden-set membership. New code builds
+  // adjacency maps + Sets once. Mirror both over a chunk of nodes.
+  const sampleIds = ids.slice(0, 200);
+  const hidden = ids.slice(0, Math.floor(ids.length / 2));
+  time('collapse neighbor scan — edges.filter [old]', () => {
+    for (const id of sampleIds) {
+      void internalEdges.filter(l => l.source === id);
+    }
+  });
+  time('collapse neighbor scan — adjacency map [new]', () => {
+    const outEdges = new Map<string, any[]>();
+    for (const edge of internalEdges) {
+      let out = outEdges.get(edge.source);
+      if (!out) {
+        out = [];
+        outEdges.set(edge.source, out);
+      }
+      out.push(edge);
+    }
+    for (const id of sampleIds) {
+      void (outEdges.get(id) ?? []);
+    }
+  });
+  time('collapse visibility filter — Array.includes [old]', () => {
+    void internalNodes.filter(node => !hidden.includes(node.id));
+  });
+  time('collapse visibility filter — Set.has [new]', () => {
+    const hiddenSet = new Set(hidden);
+    void internalNodes.filter(node => !hiddenSet.has(node.id));
+  });
+
   // --- 4. A drag frame: setNodePosition + all node self-lookups ---
   let toggle = 0;
   time('drag frame (setNodePosition + N lookups)', () => {

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -106,31 +106,37 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
   // --- 2. Per-node lookup the way <Node> resolves its own data ---
   // This selector runs once per node on EVERY store update.
   const ids = internalNodes.map(n => n.id);
-  time('node self-lookup x N (per render frame)', () => {
+  // Mirror src/symbols/Node.tsx: each node resolves its own data on every
+  // store update. Compare the old O(n) scan against the current O(1) map.
+  time('node self-lookup x N — Array.find [old]', () => {
     const state = store.getState() as any;
     for (const id of ids) {
-      // Mirror src/symbols/Node.tsx: prefer O(1) map if present.
-      const node = state.nodeMap
-        ? state.nodeMap.get(id)
-        : state.nodes.find((n: any) => n.id === id);
-      if (!node) {
+      if (!state.nodes.find((n: any) => n.id === id)) {
+        throw new Error('missing node');
+      }
+    }
+  });
+  time('node self-lookup x N — nodeMap.get [new]', () => {
+    const state = store.getState() as any;
+    for (const id of ids) {
+      if (!state.nodeMap.get(id)) {
         throw new Error('missing node');
       }
     }
   });
 
-  // --- 3. canCollapse computation the way <Node> derives it ---
-  // Mirror src/symbols/Node.tsx canCollapse.
-  time('canCollapse derivation x N', () => {
+  // --- 3. canCollapse the way <Node> derives it ---
+  // Old: O(e) edge filter per node. New: O(1) set membership.
+  time('canCollapse x N — edges.filter [old]', () => {
     const state = store.getState() as any;
     for (const id of ids) {
-      if (state.nodesWithOutboundEdges) {
-        // O(1) per node
-        const _ = state.nodesWithOutboundEdges.has(id);
-      } else {
-        // Legacy: O(E) filter per node
-        const _ = state.edges.filter((l: any) => l.source === id).length > 0;
-      }
+      void (state.edges.filter((l: any) => l.source === id).length > 0);
+    }
+  });
+  time('canCollapse x N — outboundSet.has [new]', () => {
+    const state = store.getState() as any;
+    for (const id of ids) {
+      void state.nodesWithOutboundEdges.has(id);
     }
   });
 
@@ -175,10 +181,7 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
     } as any);
     const state = store.getState() as any;
     for (const id of ids) {
-      const node = state.nodeMap
-        ? state.nodeMap.get(id)
-        : state.nodes.find((n: any) => n.id === id);
-      if (!node) {
+      if (!state.nodeMap.get(id)) {
         throw new Error('missing node');
       }
     }

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -134,6 +134,36 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
     }
   });
 
+  // --- 3b. Edge grouping (Edges.tsx) with a large selection ---
+  // Mirrors the active/inactive split. Old code did Array.includes per edge
+  // against selections/actives/hovered (O(e * s)); new code uses a Set.
+  const selection = ids
+    .slice(0, Math.floor(internalEdges.length / 5))
+    .map((_, i) => internalEdges[i].id);
+  time('edge grouping (Array.includes per edge) [old]', () => {
+    const active: any[] = [];
+    const inactive: any[] = [];
+    internalEdges.forEach(edge => {
+      if (selection.includes(edge.id)) {
+        active.push(edge);
+      } else {
+        inactive.push(edge);
+      }
+    });
+  });
+  time('edge grouping (Set.has per edge) [new]', () => {
+    const set = new Set(selection);
+    const active: any[] = [];
+    const inactive: any[] = [];
+    internalEdges.forEach(edge => {
+      if (set.has(edge.id)) {
+        active.push(edge);
+      } else {
+        inactive.push(edge);
+      }
+    });
+  });
+
   // --- 4. A drag frame: setNodePosition + all node self-lookups ---
   let toggle = 0;
   time('drag frame (setNodePosition + N lookups)', () => {

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -91,13 +91,16 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
   api.setNodes(internalNodes);
   api.setEdges(internalEdges);
 
-  console.log(
-    `\n=== ${nodeCount} nodes / ${internalEdges.length} edges ===`
-  );
+  console.log(`\n=== ${nodeCount} nodes / ${internalEdges.length} edges ===`);
 
   // --- 1. Layout transform (rebuild) cost ---
   time('transformGraph (full rebuild)', () => {
-    transformGraph({ graph, layout, sizingType: 'default', defaultNodeSize: 7 });
+    transformGraph({
+      graph,
+      layout,
+      sizingType: 'default',
+      defaultNodeSize: 7
+    });
   });
 
   // --- 2. Per-node lookup the way <Node> resolves its own data ---

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -13,6 +13,7 @@
 import Graph from 'graphology';
 import { test } from 'vitest';
 
+import { getVisibleEntities } from '../src/collapse';
 import { createStore } from '../src/store';
 import type { GraphEdge, GraphNode } from '../src/types';
 import { buildGraph, transformGraph } from '../src/utils/graph';
@@ -181,19 +182,24 @@ function runScenario(nodeCount: number, edgesPerNode: number) {
       void internalEdges.filter(l => l.source === id);
     }
   });
-  time('collapse neighbor scan — adjacency map [new]', () => {
-    const outEdges = new Map<string, any[]>();
-    for (const edge of internalEdges) {
-      let out = outEdges.get(edge.source);
-      if (!out) {
-        out = [];
-        outEdges.set(edge.source, out);
-      }
-      out.push(edge);
-    }
+  time('collapse neighbor scan — graphology [new]', () => {
+    // Mirrors the current impl: build the graph once (graphology maintains
+    // adjacency indices), then O(degree) outbound lookups.
+    const g = buildGraph(
+      new Graph({ multi: true }),
+      internalNodes as any,
+      internalEdges as any
+    );
     for (const id of sampleIds) {
-      void (outEdges.get(id) ?? []);
+      void g.mapOutEdges(id, (_k, attr) => attr);
     }
+  });
+  time('getVisibleEntities end-to-end (50 collapsed)', () => {
+    getVisibleEntities({
+      collapsedIds: ids.slice(0, 50),
+      nodes: internalNodes as any,
+      edges: internalEdges as any
+    });
   });
   time('collapse visibility filter — Array.includes [old]', () => {
     void internalNodes.filter(node => !hidden.includes(node.id));

--- a/perf/largeGraph.bench.test.ts
+++ b/perf/largeGraph.bench.test.ts
@@ -1,0 +1,160 @@
+/* eslint-disable no-console */
+/**
+ * Large-scale graph performance harness.
+ *
+ * This is NOT a unit test — it's a deterministic CPU benchmark that
+ * reproduces the per-interaction-frame work the React components perform
+ * against the Zustand store. It lets us measure the algorithmic cost of a
+ * drag/hover frame (which scales with graph size) before and after
+ * optimizations, without needing a GPU/WebGL context.
+ *
+ * Run with: npx vitest run perf/largeGraph.bench.test.ts
+ */
+import Graph from 'graphology';
+import { test } from 'vitest';
+
+import { createStore } from '../src/store';
+import type { GraphEdge, GraphNode } from '../src/types';
+import { buildGraph, transformGraph } from '../src/utils/graph';
+
+// ---------------------------------------------------------------------------
+// Fixture generation
+// ---------------------------------------------------------------------------
+
+function makeGraphData(nodeCount: number, edgesPerNode: number) {
+  const nodes: GraphNode[] = [];
+  for (let i = 0; i < nodeCount; i++) {
+    nodes.push({ id: `n-${i}`, label: `Node ${i}`, data: {} });
+  }
+
+  const edges: GraphEdge[] = [];
+  for (let i = 0; i < nodeCount; i++) {
+    for (let j = 1; j <= edgesPerNode; j++) {
+      const target = (i + j * 7) % nodeCount;
+      if (target === i) {
+        continue;
+      }
+      edges.push({
+        id: `e-${i}-${j}`,
+        source: `n-${i}`,
+        target: `n-${target}`
+      });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+// A lightweight layout stub: transformGraph only needs getNodePosition.
+// We are measuring transform/store/render-frame cost, not the d3 simulation.
+function makeLayout(nodeCount: number) {
+  const positions = new Map<string, { x: number; y: number; z: number }>();
+  for (let i = 0; i < nodeCount; i++) {
+    positions.set(`n-${i}`, {
+      x: Math.cos(i) * 500,
+      y: Math.sin(i) * 500,
+      z: 0
+    });
+  }
+  return {
+    getNodePosition: (id: string) => positions.get(id) ?? { x: 0, y: 0, z: 0 }
+  } as any;
+}
+
+function time(label: string, fn: () => void) {
+  // Warm up
+  fn();
+  const runs = 5;
+  const start = performance.now();
+  for (let i = 0; i < runs; i++) {
+    fn();
+  }
+  const ms = (performance.now() - start) / runs;
+  console.log(`  ${label.padEnd(46)} ${ms.toFixed(3)} ms`);
+  return ms;
+}
+
+function runScenario(nodeCount: number, edgesPerNode: number) {
+  const { nodes, edges } = makeGraphData(nodeCount, edgesPerNode);
+  const graph = new Graph({ multi: true });
+  buildGraph(graph, nodes, edges);
+  const layout = makeLayout(nodeCount);
+  const { nodes: internalNodes, edges: internalEdges } = transformGraph({
+    graph,
+    layout,
+    sizingType: 'default',
+    defaultNodeSize: 7
+  });
+
+  const store = createStore({});
+  const api = store.getState();
+  api.setNodes(internalNodes);
+  api.setEdges(internalEdges);
+
+  console.log(
+    `\n=== ${nodeCount} nodes / ${internalEdges.length} edges ===`
+  );
+
+  // --- 1. Layout transform (rebuild) cost ---
+  time('transformGraph (full rebuild)', () => {
+    transformGraph({ graph, layout, sizingType: 'default', defaultNodeSize: 7 });
+  });
+
+  // --- 2. Per-node lookup the way <Node> resolves its own data ---
+  // This selector runs once per node on EVERY store update.
+  const ids = internalNodes.map(n => n.id);
+  time('node self-lookup x N (per render frame)', () => {
+    const state = store.getState() as any;
+    for (const id of ids) {
+      // Mirror src/symbols/Node.tsx: prefer O(1) map if present.
+      const node = state.nodeMap
+        ? state.nodeMap.get(id)
+        : state.nodes.find((n: any) => n.id === id);
+      if (!node) {
+        throw new Error('missing node');
+      }
+    }
+  });
+
+  // --- 3. canCollapse computation the way <Node> derives it ---
+  // Mirror src/symbols/Node.tsx canCollapse.
+  time('canCollapse derivation x N', () => {
+    const state = store.getState() as any;
+    for (const id of ids) {
+      if (state.nodesWithOutboundEdges) {
+        // O(1) per node
+        const _ = state.nodesWithOutboundEdges.has(id);
+      } else {
+        // Legacy: O(E) filter per node
+        const _ = state.edges.filter((l: any) => l.source === id).length > 0;
+      }
+    }
+  });
+
+  // --- 4. A drag frame: setNodePosition + all node self-lookups ---
+  let toggle = 0;
+  time('drag frame (setNodePosition + N lookups)', () => {
+    const draggedId = ids[toggle++ % ids.length];
+    store.getState().setNodePosition(draggedId, {
+      x: Math.random() * 500,
+      y: Math.random() * 500,
+      z: 0
+    } as any);
+    const state = store.getState() as any;
+    for (const id of ids) {
+      const node = state.nodeMap
+        ? state.nodeMap.get(id)
+        : state.nodes.find((n: any) => n.id === id);
+      if (!node) {
+        throw new Error('missing node');
+      }
+    }
+  });
+}
+
+test('large graph performance baseline', () => {
+  console.log('\n========== REAGRAPH PERF HARNESS ==========');
+  runScenario(1000, 4);
+  runScenario(2500, 4);
+  runScenario(5000, 4);
+}, 120000);

--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -124,6 +124,7 @@ export const useCenterGraph = ({
   layoutType
 }: CenterGraphInput): CenterGraphOutput => {
   const nodes = useStore(state => state.nodes);
+  const nodeMap = useStore(state => state.nodeMap);
   const [isCentered, setIsCentered] = useState<boolean>(false);
   const invalidate = useThree(state => state.invalidate);
   const { controls } = useCameraControls();
@@ -215,7 +216,7 @@ export const useCenterGraph = ({
       if (nodeIds?.length) {
         // Map the node ids to the actual nodes
         mappedNodes = nodeIds.reduce((acc, id) => {
-          const node = nodes.find(n => n.id === id);
+          const node = nodeMap.get(id);
           if (node) {
             acc.push(node);
           } else {
@@ -230,7 +231,7 @@ export const useCenterGraph = ({
 
       return mappedNodes;
     },
-    [nodes]
+    [nodeMap]
   );
 
   const centerNodesById = useCallback(

--- a/src/CameraControls/useCenterGraph.ts
+++ b/src/CameraControls/useCenterGraph.ts
@@ -1,5 +1,5 @@
 import { useThree } from '@react-three/fiber';
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { PerspectiveCamera } from 'three';
 import { Box3, Vector3 } from 'three';
 
@@ -124,7 +124,11 @@ export const useCenterGraph = ({
   layoutType
 }: CenterGraphInput): CenterGraphOutput => {
   const nodes = useStore(state => state.nodes);
-  const nodeMap = useStore(state => state.nodeMap);
+  // Derive the id -> node lookup from the already-subscribed `nodes` rather
+  // than subscribing to the store's nodeMap as well — a second Map
+  // subscription would add an O(n) shallow comparison on every store update
+  // (including every drag frame). This rebuilds only when `nodes` changes.
+  const nodeMap = useMemo(() => new Map(nodes.map(n => [n.id, n])), [nodes]);
   const [isCentered, setIsCentered] = useState<boolean>(false);
   const invalidate = useThree(state => state.invalidate);
   const { controls } = useCameraControls();

--- a/src/collapse/useCollapse.ts
+++ b/src/collapse/useCollapse.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { GraphEdge, GraphNode } from '../types';
 import { getExpandPath, getVisibleEntities } from './utils';
@@ -43,32 +43,36 @@ export const useCollapse = ({
   nodes = [],
   edges = []
 }: UseCollapseProps): CollpaseResult => {
-  const getIsCollapsed = useCallback(
-    (nodeId: string) => {
-      const { visibleNodes } = getVisibleEntities({
+  // Compute visibility once per input change instead of on every call —
+  // getIsCollapsed is typically invoked per node, and each call previously
+  // re-derived the entire visible set (rebuilding the traversal graph).
+  const { visibleNodes, visibleEdges } = useMemo(
+    () =>
+      getVisibleEntities({
         nodes,
         edges,
         collapsedIds: collapsedNodeIds
-      });
-      const visibleNodeIds = visibleNodes.map(n => n.id);
-
-      return !visibleNodeIds.includes(nodeId);
-    },
+      }),
     [collapsedNodeIds, edges, nodes]
+  );
+
+  const visibleNodeIds = useMemo(
+    () => new Set(visibleNodes.map(n => n.id)),
+    [visibleNodes]
+  );
+
+  const getIsCollapsed = useCallback(
+    (nodeId: string) => !visibleNodeIds.has(nodeId),
+    [visibleNodeIds]
   );
 
   const getExpandPathIds = useCallback(
     (nodeId: string) => {
-      const { visibleEdges } = getVisibleEntities({
-        nodes,
-        edges,
-        collapsedIds: collapsedNodeIds
-      });
       const visibleEdgeIds = visibleEdges.map(e => e.id);
 
       return getExpandPath({ nodeId, edges, visibleEdgeIds });
     },
-    [collapsedNodeIds, edges, nodes]
+    [visibleEdges, edges]
   );
 
   return {

--- a/src/collapse/utils.test.ts
+++ b/src/collapse/utils.test.ts
@@ -52,6 +52,28 @@ describe('getVisibleEntities', () => {
     expect(ids(visibleEdges)).toEqual(['a->b', 'a->c', 'c->d']);
   });
 
+  test('accepts a prebuilt graph and returns identical results', async () => {
+    const Graph = (await import('graphology')).default;
+    const { buildGraph } = await import('../utils/graph');
+    const nodes = [n('a'), n('b'), n('c'), n('d')];
+    const edges = [e('a', 'b'), e('a', 'c'), e('b', 'd'), e('c', 'd')];
+    const graph = buildGraph(new Graph({ multi: true }), nodes, edges);
+
+    const withGraph = getVisibleEntities({
+      collapsedIds: ['b'],
+      nodes,
+      edges,
+      graph
+    });
+    const withoutGraph = getVisibleEntities({
+      collapsedIds: ['b'],
+      nodes,
+      edges
+    });
+    expect(ids(withGraph.visibleNodes)).toEqual(ids(withoutGraph.visibleNodes));
+    expect(ids(withGraph.visibleEdges)).toEqual(ids(withoutGraph.visibleEdges));
+  });
+
   test('collapsing both parents hides the shared child', () => {
     const nodes = [n('a'), n('b'), n('c'), n('d')];
     const edges = [e('a', 'b'), e('a', 'c'), e('b', 'd'), e('c', 'd')];

--- a/src/collapse/utils.test.ts
+++ b/src/collapse/utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+
+import type { GraphEdge, GraphNode } from '../types';
+import { getExpandPath, getVisibleEntities } from './utils';
+
+const n = (id: string): GraphNode => ({ id });
+const e = (source: string, target: string): GraphEdge => ({
+  id: `${source}->${target}`,
+  source,
+  target
+});
+
+const ids = (arr: { id: string }[]) => arr.map(x => x.id).sort();
+
+describe('getVisibleEntities', () => {
+  test('no collapsed ids returns everything', () => {
+    const nodes = [n('a'), n('b'), n('c')];
+    const edges = [e('a', 'b'), e('b', 'c')];
+    const { visibleNodes, visibleEdges } = getVisibleEntities({
+      collapsedIds: [],
+      nodes,
+      edges
+    });
+    expect(ids(visibleNodes)).toEqual(['a', 'b', 'c']);
+    expect(ids(visibleEdges)).toEqual(['a->b', 'b->c']);
+  });
+
+  test('collapsing a node hides its single-parent descendants (chain)', () => {
+    const nodes = [n('a'), n('b'), n('c'), n('d')];
+    const edges = [e('a', 'b'), e('b', 'c'), e('c', 'd')];
+    const { visibleNodes, visibleEdges } = getVisibleEntities({
+      collapsedIds: ['a'],
+      nodes,
+      edges
+    });
+    // a stays visible; b,c,d hidden along with all their edges
+    expect(ids(visibleNodes)).toEqual(['a']);
+    expect(ids(visibleEdges)).toEqual([]);
+  });
+
+  test('node with another visible parent is NOT hidden (diamond)', () => {
+    // a->b, a->c, b->d, c->d : collapsing b should keep d (c->d still feeds it)
+    const nodes = [n('a'), n('b'), n('c'), n('d')];
+    const edges = [e('a', 'b'), e('a', 'c'), e('b', 'd'), e('c', 'd')];
+    const { visibleNodes, visibleEdges } = getVisibleEntities({
+      collapsedIds: ['b'],
+      nodes,
+      edges
+    });
+    expect(ids(visibleNodes)).toEqual(['a', 'b', 'c', 'd']);
+    // only b->d hidden (outbound of b); d remains because c->d is a live parent
+    expect(ids(visibleEdges)).toEqual(['a->b', 'a->c', 'c->d']);
+  });
+
+  test('collapsing both parents hides the shared child', () => {
+    const nodes = [n('a'), n('b'), n('c'), n('d')];
+    const edges = [e('a', 'b'), e('a', 'c'), e('b', 'd'), e('c', 'd')];
+    const { visibleNodes, visibleEdges } = getVisibleEntities({
+      collapsedIds: ['b', 'c'],
+      nodes,
+      edges
+    });
+    // b,c visible; d hidden because both its inbound edges are hidden
+    expect(ids(visibleNodes)).toEqual(['a', 'b', 'c']);
+    expect(ids(visibleEdges)).toEqual(['a->b', 'a->c']);
+  });
+});
+
+describe('getExpandPath', () => {
+  test('returns parent chain when no inbound edge is visible', () => {
+    const edges = [e('a', 'b'), e('b', 'c')];
+    // c has no visible inbound edges → expand path back through b, a
+    const path = getExpandPath({
+      nodeId: 'c',
+      edges,
+      visibleEdgeIds: []
+    });
+    expect(path).toEqual(['b', 'a']);
+  });
+
+  test('returns empty when a visible inbound edge exists', () => {
+    const edges = [e('a', 'b'), e('b', 'c')];
+    const path = getExpandPath({
+      nodeId: 'c',
+      edges,
+      visibleEdgeIds: ['b->c']
+    });
+    expect(path).toEqual([]);
+  });
+});

--- a/src/collapse/utils.test.ts
+++ b/src/collapse/utils.test.ts
@@ -87,4 +87,15 @@ describe('getExpandPath', () => {
     });
     expect(path).toEqual([]);
   });
+
+  test('expands only the first parent path when multiple parents are hidden', () => {
+    // a->c and b->c both hidden: only the first inbound (a) is expanded
+    const edges = [e('a', 'c'), e('b', 'c')];
+    const path = getExpandPath({
+      nodeId: 'c',
+      edges,
+      visibleEdgeIds: []
+    });
+    expect(path).toEqual(['a']);
+  });
 });

--- a/src/collapse/utils.ts
+++ b/src/collapse/utils.ts
@@ -1,9 +1,50 @@
 import type { GraphEdge, GraphNode } from '../types';
 
+interface Adjacency {
+  /** node id -> nodes's outbound edges */
+  outEdges: Map<string, GraphEdge[]>;
+  /** node id -> node's inbound edges */
+  inEdges: Map<string, GraphEdge[]>;
+  /** node id -> node */
+  nodeMap: Map<string, GraphNode>;
+}
+
+/**
+ * Build outbound/inbound adjacency lookups once so traversal can use
+ * O(degree) neighbor access instead of scanning the full edge list (O(e))
+ * on every step.
+ */
+function buildAdjacency(nodes: GraphNode[], edges: GraphEdge[]): Adjacency {
+  const outEdges = new Map<string, GraphEdge[]>();
+  const inEdges = new Map<string, GraphEdge[]>();
+  const nodeMap = new Map<string, GraphNode>();
+
+  for (const node of nodes) {
+    nodeMap.set(node.id, node);
+  }
+
+  for (const edge of edges) {
+    let out = outEdges.get(edge.source);
+    if (!out) {
+      out = [];
+      outEdges.set(edge.source, out);
+    }
+    out.push(edge);
+
+    let inbound = inEdges.get(edge.target);
+    if (!inbound) {
+      inbound = [];
+      inEdges.set(edge.target, inbound);
+    }
+    inbound.push(edge);
+  }
+
+  return { outEdges, inEdges, nodeMap };
+}
+
 interface GetHiddenChildrenInput {
   nodeId: string;
-  nodes: GraphNode[];
-  edges: GraphEdge[];
+  adjacency: Adjacency;
   currentHiddenNodes: GraphNode[];
   currentHiddenEdges: GraphEdge[];
 }
@@ -25,23 +66,23 @@ interface GetExpandPathInput {
  */
 function getHiddenChildren({
   nodeId,
-  nodes,
-  edges,
+  adjacency,
   currentHiddenNodes,
   currentHiddenEdges
 }: GetHiddenChildrenInput) {
+  const { outEdges, inEdges, nodeMap } = adjacency;
   const hiddenNodes: GraphNode[] = [];
   const hiddenEdges: GraphEdge[] = [];
-  const curHiddenNodeIds = currentHiddenNodes.map(n => n.id);
-  const curHiddenEdgeIds = currentHiddenEdges.map(e => e.id);
+  const curHiddenNodeIds = new Set(currentHiddenNodes.map(n => n.id));
+  const curHiddenEdgeIds = new Set(currentHiddenEdges.map(e => e.id));
 
-  const outboundEdges = edges.filter(l => l.source === nodeId);
+  const outboundEdges = outEdges.get(nodeId) ?? [];
   const outboundEdgeNodeIds = outboundEdges.map(l => l.target);
 
   hiddenEdges.push(...outboundEdges);
   for (const outboundEdgeNodeId of outboundEdgeNodeIds) {
-    const incomingEdges = edges.filter(
-      l => l.target === outboundEdgeNodeId && l.source !== nodeId
+    const incomingEdges = (inEdges.get(outboundEdgeNodeId) ?? []).filter(
+      l => l.source !== nodeId
     );
     let hideNode = false;
 
@@ -50,24 +91,22 @@ function getHiddenChildren({
       hideNode = true;
     } else if (
       incomingEdges.length > 0 &&
-      !curHiddenNodeIds.includes(outboundEdgeNodeId)
+      !curHiddenNodeIds.has(outboundEdgeNodeId)
     ) {
       // If all inbound links are hidden, hide this node as well
-      const inboundNodeLinkIds = incomingEdges.map(l => l.id);
-      if (inboundNodeLinkIds.every(i => curHiddenEdgeIds.includes(i))) {
+      if (incomingEdges.every(l => curHiddenEdgeIds.has(l.id))) {
         hideNode = true;
       }
     }
     if (hideNode) {
       // Need to hide this node and any children of this node
-      const node = nodes.find(n => n.id === outboundEdgeNodeId);
+      const node = nodeMap.get(outboundEdgeNodeId);
       if (node) {
         hiddenNodes.push(node);
       }
       const nested = getHiddenChildren({
         nodeId: outboundEdgeNodeId,
-        nodes,
-        edges,
+        adjacency,
         currentHiddenEdges: hiddenEdges,
         currentHiddenNodes: hiddenNodes
       });
@@ -110,14 +149,14 @@ export const getVisibleEntities = ({
   nodes,
   edges
 }: GetVisibleIdsInput) => {
-  const curHiddenNodes = [];
-  const curHiddenEdges = [];
+  const adjacency = buildAdjacency(nodes, edges);
+  const curHiddenNodes: GraphNode[] = [];
+  const curHiddenEdges: GraphEdge[] = [];
 
   for (const collapsedId of collapsedIds) {
     const { hiddenEdges, hiddenNodes } = getHiddenChildren({
       nodeId: collapsedId,
-      nodes,
-      edges,
+      adjacency,
       currentHiddenEdges: curHiddenEdges,
       currentHiddenNodes: curHiddenNodes
     });
@@ -126,10 +165,10 @@ export const getVisibleEntities = ({
     curHiddenEdges.push(...hiddenEdges);
   }
 
-  const hiddenNodeIds = curHiddenNodes.map(n => n.id);
-  const hiddenEdgeIds = curHiddenEdges.map(e => e.id);
-  const visibleNodes = nodes.filter(n => !hiddenNodeIds.includes(n.id));
-  const visibleEdges = edges.filter(e => !hiddenEdgeIds.includes(e.id));
+  const hiddenNodeIds = new Set(curHiddenNodes.map(n => n.id));
+  const hiddenEdgeIds = new Set(curHiddenEdges.map(e => e.id));
+  const visibleNodes = nodes.filter(n => !hiddenNodeIds.has(n.id));
+  const visibleEdges = edges.filter(e => !hiddenEdgeIds.has(e.id));
 
   return {
     visibleNodes,
@@ -145,36 +184,44 @@ export const getExpandPath = ({
   edges,
   visibleEdgeIds
 }: GetExpandPathInput) => {
-  const parentIds = [];
-  const inboundEdges = edges.filter(l => l.target === nodeId);
-  const inboundEdgeIds = inboundEdges.map(e => e.id);
-  const hasVisibleInboundEdge = inboundEdgeIds.some(id =>
-    visibleEdgeIds.includes(id)
-  );
-
-  if (hasVisibleInboundEdge) {
-    // If there is a visible edge to this node, that means the node is
-    // visible so no parents need to be expanded
-    return parentIds;
-  }
-
-  const inboundEdgeNodeIds = inboundEdges.map(l => l.source);
-  let addedParent = false;
-
-  for (const inboundNodeId of inboundEdgeNodeIds) {
-    if (!addedParent) {
-      // Only want to expand a single path to the node, so if there
-      // are multiple hidden incoming edges, only expand the first
-      // to reduce how many nodes are expanded to get to the node
-      parentIds.push(
-        ...[
-          inboundNodeId,
-          ...getExpandPath({ nodeId: inboundNodeId, edges, visibleEdgeIds })
-        ]
-      );
-      addedParent = true;
+  // Build the inbound adjacency + visible set once, then walk it.
+  const inEdges = new Map<string, GraphEdge[]>();
+  for (const edge of edges) {
+    let inbound = inEdges.get(edge.target);
+    if (!inbound) {
+      inbound = [];
+      inEdges.set(edge.target, inbound);
     }
+    inbound.push(edge);
   }
+  const visibleEdgeIdSet = new Set(visibleEdgeIds);
 
-  return parentIds;
+  const walk = (id: string): string[] => {
+    const parentIds: string[] = [];
+    const inboundEdges = inEdges.get(id) ?? [];
+    const hasVisibleInboundEdge = inboundEdges.some(edge =>
+      visibleEdgeIdSet.has(edge.id)
+    );
+
+    if (hasVisibleInboundEdge) {
+      // If there is a visible edge to this node, that means the node is
+      // visible so no parents need to be expanded
+      return parentIds;
+    }
+
+    let addedParent = false;
+    for (const edge of inboundEdges) {
+      if (!addedParent) {
+        // Only want to expand a single path to the node, so if there
+        // are multiple hidden incoming edges, only expand the first
+        // to reduce how many nodes are expanded to get to the node
+        parentIds.push(...[edge.source, ...walk(edge.source)]);
+        addedParent = true;
+      }
+    }
+
+    return parentIds;
+  };
+
+  return walk(nodeId);
 };

--- a/src/collapse/utils.ts
+++ b/src/collapse/utils.ts
@@ -1,50 +1,11 @@
+import Graph from 'graphology';
+
 import type { GraphEdge, GraphNode } from '../types';
-
-interface Adjacency {
-  /** node id -> nodes's outbound edges */
-  outEdges: Map<string, GraphEdge[]>;
-  /** node id -> node's inbound edges */
-  inEdges: Map<string, GraphEdge[]>;
-  /** node id -> node */
-  nodeMap: Map<string, GraphNode>;
-}
-
-/**
- * Build outbound/inbound adjacency lookups once so traversal can use
- * O(degree) neighbor access instead of scanning the full edge list (O(e))
- * on every step.
- */
-function buildAdjacency(nodes: GraphNode[], edges: GraphEdge[]): Adjacency {
-  const outEdges = new Map<string, GraphEdge[]>();
-  const inEdges = new Map<string, GraphEdge[]>();
-  const nodeMap = new Map<string, GraphNode>();
-
-  for (const node of nodes) {
-    nodeMap.set(node.id, node);
-  }
-
-  for (const edge of edges) {
-    let out = outEdges.get(edge.source);
-    if (!out) {
-      out = [];
-      outEdges.set(edge.source, out);
-    }
-    out.push(edge);
-
-    let inbound = inEdges.get(edge.target);
-    if (!inbound) {
-      inbound = [];
-      inEdges.set(edge.target, inbound);
-    }
-    inbound.push(edge);
-  }
-
-  return { outEdges, inEdges, nodeMap };
-}
+import { buildGraph } from '../utils/graph';
 
 interface GetHiddenChildrenInput {
   nodeId: string;
-  adjacency: Adjacency;
+  graph: Graph;
   currentHiddenNodes: GraphNode[];
   currentHiddenEdges: GraphEdge[];
 }
@@ -62,26 +23,41 @@ interface GetExpandPathInput {
 }
 
 /**
+ * Get a node's outbound edges in O(degree) via graphology's adjacency index.
+ */
+const getOutboundEdges = (graph: Graph, nodeId: string): GraphEdge[] =>
+  graph.hasNode(nodeId)
+    ? graph.mapOutEdges(nodeId, (_key, attributes) => attributes as GraphEdge)
+    : [];
+
+/**
+ * Get a node's inbound edges in O(degree) via graphology's adjacency index.
+ */
+const getInboundEdges = (graph: Graph, nodeId: string): GraphEdge[] =>
+  graph.hasNode(nodeId)
+    ? graph.mapInEdges(nodeId, (_key, attributes) => attributes as GraphEdge)
+    : [];
+
+/**
  * Get the children of a node id that is hidden.
  */
 function getHiddenChildren({
   nodeId,
-  adjacency,
+  graph,
   currentHiddenNodes,
   currentHiddenEdges
 }: GetHiddenChildrenInput) {
-  const { outEdges, inEdges, nodeMap } = adjacency;
   const hiddenNodes: GraphNode[] = [];
   const hiddenEdges: GraphEdge[] = [];
   const curHiddenNodeIds = new Set(currentHiddenNodes.map(n => n.id));
   const curHiddenEdgeIds = new Set(currentHiddenEdges.map(e => e.id));
 
-  const outboundEdges = outEdges.get(nodeId) ?? [];
+  const outboundEdges = getOutboundEdges(graph, nodeId);
   const outboundEdgeNodeIds = outboundEdges.map(l => l.target);
 
   hiddenEdges.push(...outboundEdges);
   for (const outboundEdgeNodeId of outboundEdgeNodeIds) {
-    const incomingEdges = (inEdges.get(outboundEdgeNodeId) ?? []).filter(
+    const incomingEdges = getInboundEdges(graph, outboundEdgeNodeId).filter(
       l => l.source !== nodeId
     );
     let hideNode = false;
@@ -100,13 +76,14 @@ function getHiddenChildren({
     }
     if (hideNode) {
       // Need to hide this node and any children of this node
-      const node = nodeMap.get(outboundEdgeNodeId);
-      if (node) {
-        hiddenNodes.push(node);
+      if (graph.hasNode(outboundEdgeNodeId)) {
+        hiddenNodes.push(
+          graph.getNodeAttributes(outboundEdgeNodeId) as GraphNode
+        );
       }
       const nested = getHiddenChildren({
         nodeId: outboundEdgeNodeId,
-        adjacency,
+        graph,
         currentHiddenEdges: hiddenEdges,
         currentHiddenNodes: hiddenNodes
       });
@@ -149,14 +126,23 @@ export const getVisibleEntities = ({
   nodes,
   edges
 }: GetVisibleIdsInput) => {
-  const adjacency = buildAdjacency(nodes, edges);
+  // Nothing collapsed means nothing hidden. This runs on every nodes/edges
+  // change, so skip the graph construction entirely in the common case.
+  if (!collapsedIds?.length) {
+    return { visibleNodes: nodes, visibleEdges: edges };
+  }
+
+  // Build a graphology graph once (same builder the store uses) so traversal
+  // gets O(degree) neighbor access from its adjacency indices instead of
+  // scanning the edge array per node.
+  const graph = buildGraph(new Graph({ multi: true }), nodes, edges);
   const curHiddenNodes: GraphNode[] = [];
   const curHiddenEdges: GraphEdge[] = [];
 
   for (const collapsedId of collapsedIds) {
     const { hiddenEdges, hiddenNodes } = getHiddenChildren({
       nodeId: collapsedId,
-      adjacency,
+      graph,
       currentHiddenEdges: curHiddenEdges,
       currentHiddenNodes: curHiddenNodes
     });
@@ -184,21 +170,19 @@ export const getExpandPath = ({
   edges,
   visibleEdgeIds
 }: GetExpandPathInput) => {
-  // Build the inbound adjacency + visible set once, then walk it.
-  const inEdges = new Map<string, GraphEdge[]>();
+  // Only edges are available here, so let graphology create the endpoints
+  // implicitly via mergeNode and use its inbound adjacency for the walk.
+  const graph = new Graph({ multi: true });
   for (const edge of edges) {
-    let inbound = inEdges.get(edge.target);
-    if (!inbound) {
-      inbound = [];
-      inEdges.set(edge.target, inbound);
-    }
-    inbound.push(edge);
+    graph.mergeNode(edge.source);
+    graph.mergeNode(edge.target);
+    graph.addEdge(edge.source, edge.target, edge);
   }
   const visibleEdgeIdSet = new Set(visibleEdgeIds);
 
   const walk = (id: string): string[] => {
     const parentIds: string[] = [];
-    const inboundEdges = inEdges.get(id) ?? [];
+    const inboundEdges = getInboundEdges(graph, id);
     const hasVisibleInboundEdge = inboundEdges.some(edge =>
       visibleEdgeIdSet.has(edge.id)
     );

--- a/src/collapse/utils.ts
+++ b/src/collapse/utils.ts
@@ -14,6 +14,13 @@ interface GetVisibleIdsInput {
   collapsedIds: string[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  /**
+   * Optional prebuilt graphology graph of the FULL node/edge set (e.g. built
+   * once by the caller and reused across collapse/expand interactions).
+   * Must contain the same nodes/edges passed above. Note the store's graph
+   * is NOT suitable here: it holds the post-collapse visible subgraph.
+   */
+  graph?: Graph;
 }
 
 interface GetExpandPathInput {
@@ -124,7 +131,8 @@ function getHiddenChildren({
 export const getVisibleEntities = ({
   collapsedIds,
   nodes,
-  edges
+  edges,
+  graph: providedGraph
 }: GetVisibleIdsInput) => {
   // Nothing collapsed means nothing hidden. This runs on every nodes/edges
   // change, so skip the graph construction entirely in the common case.
@@ -132,10 +140,12 @@ export const getVisibleEntities = ({
     return { visibleNodes: nodes, visibleEdges: edges };
   }
 
-  // Build a graphology graph once (same builder the store uses) so traversal
-  // gets O(degree) neighbor access from its adjacency indices instead of
-  // scanning the edge array per node.
-  const graph = buildGraph(new Graph({ multi: true }), nodes, edges);
+  // Use the caller's prebuilt graph when supplied; otherwise build one
+  // (same builder the store uses) so traversal gets O(degree) neighbor
+  // access from graphology's adjacency indices instead of scanning the
+  // edge array per node.
+  const graph =
+    providedGraph ?? buildGraph(new Graph({ multi: true }), nodes, edges);
   const curHiddenNodes: GraphNode[] = [];
   const curHiddenEdges: GraphEdge[] = [];
 

--- a/src/layout/forceInABox.ts
+++ b/src/layout/forceInABox.ts
@@ -242,6 +242,10 @@ export function forceInABox() {
     let linkCount = 0;
     if (nodes.length === 0) return;
 
+    // Build an id -> node lookup once instead of scanning the node array for
+    // every link endpoint (was O(links * nodes)).
+    const nodeById = new Map(nodes.map(n => [n.id, n]));
+
     links.forEach(function (link) {
       let source, target;
       if (!nodes) {
@@ -252,11 +256,11 @@ export function forceInABox() {
       target = link.target;
 
       if (typeof link.source !== 'object') {
-        source = nodes.find(n => n.id === link.source);
+        source = nodeById.get(link.source);
       }
 
       if (typeof link.target !== 'object') {
-        target = nodes.find(n => n.id === link.target);
+        target = nodeById.get(link.target);
       }
 
       if (source === undefined || target === undefined) {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -42,6 +42,33 @@ describe('store lookup maps', () => {
     expect(nodesWithOutboundEdges.has('c')).toBe(false);
   });
 
+  test('setNodes shrinking removes stale entries from the node map', () => {
+    const store = createStore({});
+    store.getState().setNodes([makeNode('a'), makeNode('b'), makeNode('c')]);
+    // Simulate removing a node (e.g. data change / collapse)
+    store.getState().setNodes([makeNode('a'), makeNode('c')]);
+
+    const { nodeMap } = store.getState();
+    expect(nodeMap.size).toBe(2);
+    expect(nodeMap.has('b')).toBe(false);
+    expect(nodeMap.has('a')).toBe(true);
+  });
+
+  test('setEdges shrinking removes stale entries and updates outbound set', () => {
+    const store = createStore({});
+    store
+      .getState()
+      .setEdges([makeEdge('e1', 'a', 'b'), makeEdge('e2', 'a', 'c')]);
+    // Remove the only edge that gave 'a' an outbound edge via e1, keep e2
+    store.getState().setEdges([makeEdge('e2', 'a', 'c')]);
+
+    const { edgeMap, nodesWithOutboundEdges } = store.getState();
+    expect(edgeMap.has('e1')).toBe(false);
+    expect(edgeMap.has('e2')).toBe(true);
+    expect(nodesWithOutboundEdges.has('a')).toBe(true);
+    expect(nodesWithOutboundEdges.has('b')).toBe(false);
+  });
+
   test('setNodePosition updates the moved node and keeps others stable', () => {
     const store = createStore({});
     const nodes = [makeNode('a', 0, 0), makeNode('b', 10, 10)];

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+
+import { createStore } from './store';
+import type { InternalGraphEdge, InternalGraphNode } from './types';
+
+const makeNode = (id: string, x = 0, y = 0, z = 0): InternalGraphNode =>
+  ({
+    id,
+    position: { id, x, y, z } as any,
+    size: 7
+  }) as InternalGraphNode;
+
+const makeEdge = (id: string, source: string, target: string) =>
+  ({ id, source, target }) as InternalGraphEdge;
+
+describe('store lookup maps', () => {
+  test('setNodes builds an id -> node map in sync with nodes', () => {
+    const store = createStore({});
+    const nodes = [makeNode('a'), makeNode('b'), makeNode('c')];
+    store.getState().setNodes(nodes);
+
+    const { nodeMap } = store.getState();
+    expect(nodeMap.size).toBe(3);
+    expect(nodeMap.get('b')).toBe(nodes[1]);
+    expect(nodeMap.get('missing')).toBeUndefined();
+  });
+
+  test('setEdges builds edge map and outbound-edge set', () => {
+    const store = createStore({});
+    const edges = [
+      makeEdge('e1', 'a', 'b'),
+      makeEdge('e2', 'a', 'c'),
+      makeEdge('e3', 'b', 'c')
+    ];
+    store.getState().setEdges(edges);
+
+    const { edgeMap, nodesWithOutboundEdges } = store.getState();
+    expect(edgeMap.get('e2')).toBe(edges[1]);
+    // a and b have outbound edges, c does not
+    expect(nodesWithOutboundEdges.has('a')).toBe(true);
+    expect(nodesWithOutboundEdges.has('b')).toBe(true);
+    expect(nodesWithOutboundEdges.has('c')).toBe(false);
+  });
+
+  test('setNodePosition updates the moved node and keeps others stable', () => {
+    const store = createStore({});
+    const nodes = [makeNode('a', 0, 0), makeNode('b', 10, 10)];
+    store.getState().setNodes(nodes);
+
+    store.getState().setNodePosition('a', { id: 'a', x: 5, y: 5, z: 0 } as any);
+
+    const state = store.getState();
+    // Moved node is replaced in both array and map, with consistent identity
+    const movedFromArray = state.nodes.find(n => n.id === 'a');
+    expect(state.nodeMap.get('a')).toBe(movedFromArray);
+    expect(state.nodeMap.get('a').position.x).toBe(5);
+    // Untouched node keeps its referential identity (prevents re-render churn)
+    expect(state.nodeMap.get('b')).toBe(nodes[1]);
+  });
+
+  test('setNodePosition moves the whole selection when dragging a selected node', () => {
+    const store = createStore({ selections: ['a', 'b'] });
+    const nodes = [
+      makeNode('a', 0, 0),
+      makeNode('b', 0, 0),
+      makeNode('c', 0, 0)
+    ];
+    store.getState().setNodes(nodes);
+
+    store.getState().setNodePosition('a', { id: 'a', x: 4, y: 0, z: 0 } as any);
+
+    const state = store.getState();
+    expect(state.nodeMap.get('a').position.x).toBe(4);
+    expect(state.nodeMap.get('b').position.x).toBe(4);
+    // Unselected node is unchanged
+    expect(state.nodeMap.get('c')).toBe(nodes[2]);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,9 +22,62 @@ export type DragReferences = {
   [key: string]: InternalGraphNode;
 };
 
+/**
+ * Build the id -> node lookup map used for O(1) node access.
+ */
+const buildNodeMap = (
+  nodes: InternalGraphNode[]
+): Map<string, InternalGraphNode> => {
+  const map = new Map<string, InternalGraphNode>();
+  for (const node of nodes) {
+    map.set(node.id, node);
+  }
+  return map;
+};
+
+/**
+ * Build the set of node ids that have at least one outbound edge.
+ */
+const buildOutboundSet = (edges: InternalGraphEdge[]): Set<string> => {
+  const set = new Set<string>();
+  for (const edge of edges) {
+    set.add(edge.source);
+  }
+  return set;
+};
+
+/**
+ * Build the id -> edge lookup map used for O(1) edge access.
+ */
+const buildEdgeMap = (
+  edges: InternalGraphEdge[]
+): Map<string, InternalGraphEdge> => {
+  const map = new Map<string, InternalGraphEdge>();
+  for (const edge of edges) {
+    map.set(edge.id, edge);
+  }
+  return map;
+};
+
 export interface GraphState {
   nodes: InternalGraphNode[];
   edges: InternalGraphEdge[];
+  /**
+   * O(1) lookup of a node by its id. Kept in sync with `nodes`.
+   * Avoids O(n) `nodes.find` scans inside per-node components, which
+   * otherwise make rendering/dragging O(n^2) on large graphs.
+   */
+  nodeMap: Map<string, InternalGraphNode>;
+  /**
+   * Set of node ids that have at least one outbound edge. Kept in sync
+   * with `edges`. Lets a node determine `canCollapse` in O(1) instead of
+   * filtering the entire edge list (O(n*e)) on every render.
+   */
+  nodesWithOutboundEdges: Set<string>;
+  /**
+   * O(1) lookup of an edge by its id. Kept in sync with `edges`.
+   */
+  edgeMap: Map<string, InternalGraphEdge>;
   graph: Graph;
   clusters: Map<string, ClusterGroup>;
   collapsedNodeIds?: string[];
@@ -80,6 +133,9 @@ export const createStore = ({
     },
     edges: [],
     nodes: [],
+    nodeMap: new Map(),
+    nodesWithOutboundEdges: new Set(),
+    edgeMap: new Map(),
     collapsedNodeIds,
     clusters: new Map(),
     panning: false,
@@ -119,30 +175,43 @@ export const createStore = ({
       set(state => ({
         ...state,
         nodes,
+        nodeMap: buildNodeMap(nodes),
         centerPosition: getLayoutCenter(nodes)
       })),
-    setEdges: edges => set(state => ({ ...state, edges })),
+    setEdges: edges =>
+      set(state => ({
+        ...state,
+        edges,
+        edgeMap: buildEdgeMap(edges),
+        nodesWithOutboundEdges: buildOutboundSet(edges)
+      })),
     setNodePosition: (id, position) =>
       set(state => {
-        const node = state.nodes.find(n => n.id === id);
+        const node =
+          state.nodeMap.get(id) ?? state.nodes.find(n => n.id === id);
         const originalVector = getVector(node);
         const newVector = new Vector3(position.x, position.y, position.z);
         const offset = newVector.sub(originalVector);
-        const nodes = [...state.nodes];
 
-        if (state.selections?.includes(id)) {
-          state.selections?.forEach(id => {
-            const node = state.nodes.find(n => n.id === id);
-            // Selections can contain edges:
-            if (node) {
-              const nodeIndex = state.nodes.indexOf(node);
-              nodes[nodeIndex] = updateNodePosition(node, offset);
-            }
-          });
-        } else {
-          const nodeIndex = state.nodes.indexOf(node);
-          nodes[nodeIndex] = updateNodePosition(node, offset);
-        }
+        // Determine which nodes move: a multi-selection drags all selected
+        // nodes, otherwise just the dragged node.
+        const idsToMove =
+          state.selections?.includes(id) && state.selections.length
+            ? state.selections
+            : [id];
+        const moving = new Set(idsToMove);
+
+        // Single O(n) pass producing both the new array and the new lookup map
+        // with O(1) per-node access (no nested find/indexOf scans).
+        const nodeMap = new Map(state.nodeMap);
+        const nodes = state.nodes.map(n => {
+          if (moving.has(n.id)) {
+            const updated = updateNodePosition(n, offset);
+            nodeMap.set(n.id, updated);
+            return updated;
+          }
+          return n;
+        });
 
         return {
           ...state,
@@ -150,7 +219,8 @@ export const createStore = ({
             ...state.drags,
             [id]: node
           },
-          nodes
+          nodes,
+          nodeMap
         };
       }),
     setCollapsedNodeIds: (nodeIds = []) =>
@@ -172,6 +242,7 @@ export const createStore = ({
 
           // Update all nodes in the cluster
           const nodes: InternalGraphNode[] = [...state.nodes];
+          const nodeMap = new Map(state.nodeMap);
           const drags: DragReferences = { ...state.drags };
           nodes.forEach((node, index) => {
             if (node.cluster === id) {
@@ -184,6 +255,7 @@ export const createStore = ({
                   z: node.position.z + (offset.z ?? 0)
                 } as InternalGraphPosition
               };
+              nodeMap.set(node.id, nodes[index]);
               // Update node in drag reference
               drags[node.id] = node;
             }
@@ -206,7 +278,8 @@ export const createStore = ({
               [id]: cluster
             },
             clusters,
-            nodes
+            nodes,
+            nodeMap
           };
         }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -188,6 +188,11 @@ export const createStore = ({
     setNodePosition: (id, position) =>
       set(state => {
         const node = state.nodeMap.get(id);
+        // Guard against a position update for a node that is no longer in the
+        // store (e.g. removed mid-drag) — no-op rather than dereferencing it.
+        if (!node) {
+          return state;
+        }
         const originalVector = getVector(node);
         const newVector = new Vector3(position.x, position.y, position.z);
         const offset = newVector.sub(originalVector);

--- a/src/store.ts
+++ b/src/store.ts
@@ -187,22 +187,23 @@ export const createStore = ({
       })),
     setNodePosition: (id, position) =>
       set(state => {
-        const node =
-          state.nodeMap.get(id) ?? state.nodes.find(n => n.id === id);
+        const node = state.nodeMap.get(id);
         const originalVector = getVector(node);
         const newVector = new Vector3(position.x, position.y, position.z);
         const offset = newVector.sub(originalVector);
 
         // Determine which nodes move: a multi-selection drags all selected
-        // nodes, otherwise just the dragged node.
-        const idsToMove =
-          state.selections?.includes(id) && state.selections.length
-            ? state.selections
-            : [id];
+        // nodes, otherwise just the dragged node. (selections may also contain
+        // edge ids — those simply won't match any node below and are ignored.)
+        const idsToMove = state.selections?.includes(id)
+          ? state.selections
+          : [id];
         const moving = new Set(idsToMove);
 
         // Single O(n) pass producing both the new array and the new lookup map
-        // with O(1) per-node access (no nested find/indexOf scans).
+        // with O(1) per-node access (no nested find/indexOf scans). The map is
+        // copied (not mutated) because subscribers select it by reference, so
+        // it must change identity for change detection to fire.
         const nodeMap = new Map(state.nodeMap);
         const nodes = state.nodes.map(n => {
           if (moving.has(n.id)) {

--- a/src/symbols/Edge.tsx
+++ b/src/symbols/Edge.tsx
@@ -155,8 +155,9 @@ export const Edge: FC<EdgeProps> = ({
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
 
   // Edge data
+  const edge = useStore(state => state.edgeMap.get(id));
+  // Needed to compute parallel-edge curve offsets (animated path only).
   const edges = useStore(state => state.edges);
-  const edge = edges.find(e => e.id === id);
   const {
     target,
     source,
@@ -173,8 +174,8 @@ export const Edge: FC<EdgeProps> = ({
   const effectiveSubLabelPlacement =
     edge.subLabelPlacement || subLabelPlacement;
 
-  const from = useStore(store => store.nodes.find(node => node.id === source));
-  const to = useStore(store => store.nodes.find(node => node.id === target));
+  const from = useStore(store => store.nodeMap.get(source));
+  const to = useStore(store => store.nodeMap.get(target));
 
   // Detect self-loop
   const isSelfLoop = from.id === to.id;

--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -134,8 +134,10 @@ export const Node: FC<NodeProps> = ({
 }) => {
   const cameraControls = useCameraControls();
   const theme = useStore(state => state.theme);
-  const node = useStore(state => state.nodes.find(n => n.id === id));
-  const edges = useStore(state => state.edges);
+  const node = useStore(state => state.nodeMap.get(id));
+  const hasOutboundEdges = useStore(state =>
+    state.nodesWithOutboundEdges.has(id)
+  );
   const draggingIds = useStore(state => state.draggingIds);
   const collapsedNodeIds = useStore(state => state.collapsedNodeIds);
   const addDraggingId = useStore(state => state.addDraggingId);
@@ -175,10 +177,8 @@ export const Node: FC<NodeProps> = ({
 
   const canCollapse = useMemo(() => {
     // If the node has outgoing edges, it can collapse via context menu
-    const outboundLinks = edges.filter(l => l.source === id);
-
-    return outboundLinks.length > 0 || isCollapsed;
-  }, [edges, id, isCollapsed]);
+    return hasOutboundEdges || isCollapsed;
+  }, [hasOutboundEdges, isCollapsed]);
 
   const onCollapse = useCallback(() => {
     if (canCollapse) {

--- a/src/symbols/Ring.tsx
+++ b/src/symbols/Ring.tsx
@@ -1,11 +1,30 @@
 import { a, useSpring } from '@react-spring/three';
 import { Billboard } from '@react-three/drei';
 import type { FC } from 'react';
-import React, { useMemo } from 'react';
-import type { ColorRepresentation } from 'three';
-import { Color, DoubleSide } from 'three';
+import React, { useEffect, useMemo, useRef } from 'react';
+import type { ColorRepresentation, MeshBasicMaterial } from 'three';
+import { Color, DoubleSide, RingGeometry } from 'three';
 
 import { animationConfig } from '../utils/animation';
+
+// Ring geometries only depend on their radius/segment args, which are
+// almost always the same across every node's selection ring. Cache and
+// share one geometry per unique arg combination instead of allocating one
+// per node. Shared geometries are guarded with `dispose={null}`.
+const ringGeometryCache = new Map<string, RingGeometry>();
+const getRingGeometry = (
+  innerRadius: number,
+  outerRadius: number,
+  segments: number
+): RingGeometry => {
+  const key = `${innerRadius}|${outerRadius}|${segments}`;
+  let geometry = ringGeometryCache.get(key);
+  if (!geometry) {
+    geometry = new RingGeometry(innerRadius, outerRadius, segments);
+    ringGeometryCache.set(key, geometry);
+  }
+  return geometry;
+};
 
 export interface RingProps {
   /**
@@ -85,19 +104,28 @@ export const Ring: FC<RingProps> = ({
   const strokeWidthFraction = strokeWidth / 10;
   const outerRadius = innerRadius + strokeWidthFraction;
 
+  const geometry = useMemo(
+    () => getRingGeometry(innerRadius, outerRadius, segments),
+    [innerRadius, outerRadius, segments]
+  );
+
+  // The geometry is shared (dispose={null}), so dispose the per-ring
+  // material ourselves on unmount.
+  const materialRef = useRef<MeshBasicMaterial | null>(null);
+  useEffect(() => () => materialRef.current?.dispose(), []);
+
   return (
     <Billboard position={[0, 0, 1]}>
       <a.mesh
         scale={ringSize as any}
+        geometry={geometry}
+        dispose={null}
         // Disabling raycast/pointer events when ring is invisible (opacity = 0)
         // This prevents invisible rings highlighting parent nodes when hovered over
         raycast={opacity > 0 ? undefined : () => []}
       >
-        <ringGeometry
-          attach="geometry"
-          args={[innerRadius, outerRadius, segments]}
-        />
         <a.meshBasicMaterial
+          ref={materialRef as any}
           attach="material"
           color={normalizedColor}
           transparent={true}

--- a/src/symbols/edges/Edge.tsx
+++ b/src/symbols/edges/Edge.tsx
@@ -88,14 +88,10 @@ export const Edge: FC<EdgeProps> = ({
   const theme = useStore(state => state.theme);
   const { target, source, label, labelVisible = false, size = 1 } = edge;
 
-  const nodes = useStore(store => store.nodes);
-  const [from, to] = useMemo(
-    () => [
-      nodes.find(node => node.id === source),
-      nodes.find(node => node.id === target)
-    ],
-    [nodes, source, target]
-  );
+  // Subscribe only to the two endpoints (O(1) lookups) instead of the whole
+  // node array — otherwise every edge re-renders on every node change.
+  const from = useStore(store => store.nodeMap.get(source));
+  const to = useStore(store => store.nodeMap.get(target));
   const isDragging = useStore(state => state.draggingIds.length > 0);
 
   const labelOffset = useMemo(

--- a/src/symbols/edges/Edges.tsx
+++ b/src/symbols/edges/Edges.tsx
@@ -202,9 +202,16 @@ export const Edges: FC<EdgesProps> = ({
       if (!intersections.length) {
         return [];
       }
-      return intersections.map(intersection =>
-        meshToEdge.get(intersection.object)
-      );
+      // Resolve hits to edges, dropping any that don't map (defensive: keeps
+      // undefined out of the hovered set, event handlers and getGeometry).
+      const hits: Array<InternalGraphEdge> = [];
+      for (const intersection of intersections) {
+        const edge = meshToEdge.get(intersection.object);
+        if (edge) {
+          hits.push(edge);
+        }
+      }
+      return hits;
     },
     [edgeMeshes, meshToEdge]
   );

--- a/src/symbols/edges/Edges.tsx
+++ b/src/symbols/edges/Edges.tsx
@@ -172,6 +172,16 @@ export const Edges: FC<EdgesProps> = ({
   const staticEdgesRef = useRef(new Mesh());
   const dynamicEdgesRef = useRef(new Mesh());
 
+  // O(1) mesh -> edge lookup so resolving raycaster hits doesn't scan the
+  // entire edge mesh array (was O(e) per intersection, every frame).
+  const meshToEdge = useMemo(() => {
+    const map = new Map<Mesh, InternalGraphEdge>();
+    for (let i = 0; i < edgeMeshes.length; i++) {
+      map.set(edgeMeshes[i], edges[i]);
+    }
+    return map;
+  }, [edgeMeshes, edges]);
+
   const intersect = useCallback(
     (raycaster: Raycaster): Array<InternalGraphEdge> => {
       // Handle initial raycaster state:
@@ -183,11 +193,11 @@ export const Edges: FC<EdgesProps> = ({
       if (!intersections.length) {
         return [];
       }
-      return intersections.map(
-        intersection => edges[edgeMeshes.indexOf(intersection.object)]
+      return intersections.map(intersection =>
+        meshToEdge.get(intersection.object)
       );
     },
-    [edgeMeshes, edges]
+    [edgeMeshes, meshToEdge]
   );
 
   const { handleClick, handleContextMenu, handleIntersections } = useEdgeEvents(
@@ -231,7 +241,18 @@ export const Edges: FC<EdgesProps> = ({
     const intersecting = intersect(state.raycaster);
     handleIntersections(previousIntersecting, intersecting);
 
-    if (intersecting.join() !== previousIntersecting.join()) {
+    // Compare by edge identity rather than Array.join() (which stringified
+    // edge objects to "[object Object]" and only effectively compared count).
+    let changed = intersecting.length !== previousIntersecting.length;
+    if (!changed) {
+      for (let i = 0; i < intersecting.length; i++) {
+        if (intersecting[i] !== previousIntersecting[i]) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (changed) {
       dynamicEdgesRef.current.geometry = getGeometry(intersecting, []);
     }
 

--- a/src/symbols/edges/Edges.tsx
+++ b/src/symbols/edges/Edges.tsx
@@ -116,16 +116,25 @@ export const Edges: FC<EdgesProps> = ({
     const inactive: Array<InternalGraphEdge> = [];
     const draggingActive: Array<InternalGraphEdge> = [];
     const draggingInactive: Array<InternalGraphEdge> = [];
+
+    // Build O(1) membership lookups once instead of scanning these arrays
+    // for every edge (was O(e * (s + a + d + h))).
+    const draggingSet = new Set(draggingIds);
+    const activeEdgeSet = new Set<string>();
+    for (const id of selections) {
+      activeEdgeSet.add(id);
+    }
+    for (const id of actives) {
+      activeEdgeSet.add(id);
+    }
+    for (const id of hoveredEdgeIds) {
+      activeEdgeSet.add(id);
+    }
+
     edges.forEach(edge => {
-      if (
-        draggingIds.includes(edge.source) ||
-        draggingIds.includes(edge.target)
-      ) {
-        if (
-          selections.includes(edge.id) ||
-          actives.includes(edge.id) ||
-          hoveredEdgeIds.includes(edge.id)
-        ) {
+      const isActive = activeEdgeSet.has(edge.id);
+      if (draggingSet.has(edge.source) || draggingSet.has(edge.target)) {
+        if (isActive) {
           draggingActive.push(edge);
         } else {
           draggingInactive.push(edge);
@@ -133,11 +142,7 @@ export const Edges: FC<EdgesProps> = ({
         return;
       }
 
-      if (
-        selections.includes(edge.id) ||
-        actives.includes(edge.id) ||
-        hoveredEdgeIds.includes(edge.id)
-      ) {
+      if (isActive) {
         active.push(edge);
       } else {
         inactive.push(edge);
@@ -147,6 +152,16 @@ export const Edges: FC<EdgesProps> = ({
   }, [edges, actives, selections, draggingIds, hoveredEdgeIds]);
 
   const hasSelections = !!selections.length;
+
+  // O(1) membership lookups for the per-edge render pass below.
+  const edgeStateSets = useMemo(
+    () => ({
+      selectionSet: new Set(selections),
+      activeSet: new Set(actives),
+      hoveredSet: new Set(hoveredEdgeIds)
+    }),
+    [selections, actives, hoveredEdgeIds]
+  );
 
   const staticEdgesGeometry = useMemo(
     () => getGeometry(active, inactive),
@@ -304,9 +319,9 @@ export const Edges: FC<EdgesProps> = ({
         />
       </mesh>
       {edges.map(edge => {
-        const isSelected = selections.includes(edge.id);
-        const isActive = actives.includes(edge.id);
-        const isHovered = hoveredEdgeIds.includes(edge.id);
+        const isSelected = edgeStateSets.selectionSet.has(edge.id);
+        const isActive = edgeStateSets.activeSet.has(edge.id);
+        const isHovered = edgeStateSets.hoveredSet.has(edge.id);
 
         return (
           <Edge

--- a/src/symbols/edges/Edges.tsx
+++ b/src/symbols/edges/Edges.tsx
@@ -111,28 +111,32 @@ export const Edges: FC<EdgesProps> = ({
   const selections = useStore(state => state.selections || []);
   const hoveredEdgeIds = useStore(state => state.hoveredEdgeIds || []);
 
+  // O(1) membership lookups, built once and reused by both the active/inactive
+  // grouping below and the per-edge render pass — instead of scanning these
+  // arrays for every edge (was O(e * (s + a + h))).
+  const edgeStateSets = useMemo(
+    () => ({
+      selectionSet: new Set(selections),
+      activeSet: new Set(actives),
+      hoveredSet: new Set(hoveredEdgeIds)
+    }),
+    [selections, actives, hoveredEdgeIds]
+  );
+
   const [active, inactive, draggingActive, draggingInactive] = useMemo(() => {
     const active: Array<InternalGraphEdge> = [];
     const inactive: Array<InternalGraphEdge> = [];
     const draggingActive: Array<InternalGraphEdge> = [];
     const draggingInactive: Array<InternalGraphEdge> = [];
 
-    // Build O(1) membership lookups once instead of scanning these arrays
-    // for every edge (was O(e * (s + a + d + h))).
+    const { selectionSet, activeSet, hoveredSet } = edgeStateSets;
     const draggingSet = new Set(draggingIds);
-    const activeEdgeSet = new Set<string>();
-    for (const id of selections) {
-      activeEdgeSet.add(id);
-    }
-    for (const id of actives) {
-      activeEdgeSet.add(id);
-    }
-    for (const id of hoveredEdgeIds) {
-      activeEdgeSet.add(id);
-    }
 
     edges.forEach(edge => {
-      const isActive = activeEdgeSet.has(edge.id);
+      const isActive =
+        selectionSet.has(edge.id) ||
+        activeSet.has(edge.id) ||
+        hoveredSet.has(edge.id);
       if (draggingSet.has(edge.source) || draggingSet.has(edge.target)) {
         if (isActive) {
           draggingActive.push(edge);
@@ -149,19 +153,9 @@ export const Edges: FC<EdgesProps> = ({
       }
     });
     return [active, inactive, draggingActive, draggingInactive];
-  }, [edges, actives, selections, draggingIds, hoveredEdgeIds]);
+  }, [edges, draggingIds, edgeStateSets]);
 
   const hasSelections = !!selections.length;
-
-  // O(1) membership lookups for the per-edge render pass below.
-  const edgeStateSets = useMemo(
-    () => ({
-      selectionSet: new Set(selections),
-      activeSet: new Set(actives),
-      hoveredSet: new Set(hoveredEdgeIds)
-    }),
-    [selections, actives, hoveredEdgeIds]
-  );
 
   const staticEdgesGeometry = useMemo(
     () => getGeometry(active, inactive),
@@ -256,12 +250,15 @@ export const Edges: FC<EdgesProps> = ({
     const intersecting = intersect(state.raycaster);
     handleIntersections(previousIntersecting, intersecting);
 
-    // Compare by edge identity rather than Array.join() (which stringified
-    // edge objects to "[object Object]" and only effectively compared count).
+    // Compare the hovered set by edge id rather than Array.join() (which
+    // stringified edge objects to "[object Object]" and only effectively
+    // compared count). Comparing by id (not object identity) avoids needless
+    // geometry rebuilds when the edges array is replaced with new objects for
+    // the same logical edges, and tolerates undefined entries.
     let changed = intersecting.length !== previousIntersecting.length;
     if (!changed) {
       for (let i = 0; i < intersecting.length; i++) {
-        if (intersecting[i] !== previousIntersecting[i]) {
+        if (intersecting[i]?.id !== previousIntersecting[i]?.id) {
           changed = true;
           break;
         }

--- a/src/symbols/edges/useEdgeGeometry.ts
+++ b/src/symbols/edges/useEdgeGeometry.ts
@@ -35,6 +35,17 @@ export type UseEdgeGeometry = {
 
 const NULL_GEOMETRY = createNullGeometry();
 
+/**
+ * Upper bound on the per-edge geometry cache. The cache is keyed by endpoint
+ * positions, so during a drag/layout it gains a fresh entry every frame for
+ * every moving edge — without a bound it grows for the lifetime of the
+ * interaction. When the bound is exceeded we drop the cache (entries still
+ * referenced by live meshes survive via those references and are reclaimed by
+ * GC once unreferenced); subsequent renders simply repopulate it. Sized well
+ * above a typical static working set so it only acts as a long-session valve.
+ */
+const MAX_EDGE_GEOMETRY_CACHE_SIZE = 100_000;
+
 export function useEdgeGeometry(
   arrowPlacement: EdgeArrowPosition,
   interpolation: EdgeInterpolation
@@ -58,9 +69,17 @@ export function useEdgeGeometry(
       const geometries: Array<BufferGeometry> = [];
       const cache = geometryCacheRef.current;
 
-      // Pre-compute values outside the loop
-      const { nodes } = stateRef.current;
-      const nodesMap = new Map(nodes.map(node => [node.id, node]));
+      // Bound the position-keyed cache so a long drag/layout can't grow it
+      // without limit. Dropping the map is safe: geometries still referenced
+      // by live meshes stay alive through those references, and the rest are
+      // GC'd. This rarely triggers for static graphs (sized above their
+      // working set) and only repopulates on the next render when it does.
+      if (cache.size > MAX_EDGE_GEOMETRY_CACHE_SIZE) {
+        cache.clear();
+      }
+
+      // Reuse the store's id -> node map instead of rebuilding one every call.
+      const nodesMap = stateRef.current.nodeMap;
 
       // Initialize base arrow geometry if needed
       if (arrowPlacement !== 'none' && !baseArrowGeometryRef.current) {

--- a/src/symbols/nodes/Sphere.tsx
+++ b/src/symbols/nodes/Sphere.tsx
@@ -69,12 +69,19 @@ export const Sphere: FC<NodeRendererProps> = ({
           emissiveIntensity={0.7}
         />
       </a.mesh>
-      <Ring
-        opacity={selected ? 0.5 : 0}
-        size={size}
-        animated={animated}
-        color={selected ? theme.ring.activeFill : theme.ring.fill}
-      />
+      {/* Only mount the selection ring (and its per-frame Billboard) when
+          the node is actually selected. The ring was already invisible
+          (opacity 0) when unselected, so this preserves the visible result
+          while removing one camera-facing Billboard per unselected node —
+          a large per-frame win on big graphs. */}
+      {selected && (
+        <Ring
+          opacity={0.5}
+          size={size}
+          animated={animated}
+          color={theme.ring.activeFill}
+        />
+      )}
     </>
   );
 };

--- a/src/symbols/nodes/Sphere.tsx
+++ b/src/symbols/nodes/Sphere.tsx
@@ -1,12 +1,22 @@
 import { a, useSpring } from '@react-spring/three';
 import type { FC } from 'react';
-import React, { useMemo } from 'react';
-import { Color, DoubleSide } from 'three';
+import React, { useEffect, useMemo, useRef } from 'react';
+import type { MeshPhongMaterial } from 'three';
+import { Color, DoubleSide, SphereGeometry } from 'three';
 
 import { useStore } from '../../store';
 import type { NodeRendererProps } from '../../types';
 import { animationConfig } from '../../utils/animation';
 import { Ring } from '../Ring';
+
+// All default sphere nodes use an identical unit-sphere geometry that is
+// scaled per-node by the mesh transform, so we share a single geometry
+// instance instead of allocating one BufferGeometry per node. On large
+// graphs this avoids tens/hundreds of MB of duplicated GPU buffers.
+// `dispose={null}` on the mesh keeps R3F from disposing this shared
+// geometry when an individual node unmounts (we dispose the per-node
+// material manually instead).
+const SPHERE_GEOMETRY = new SphereGeometry(1, 25, 25);
 
 export const Sphere: FC<NodeRendererProps> = ({
   color,
@@ -34,11 +44,21 @@ export const Sphere: FC<NodeRendererProps> = ({
   const normalizedColor = useMemo(() => new Color(color), [color]);
   const theme = useStore(state => state.theme);
 
+  // The geometry is shared (dispose={null}), so dispose the per-node
+  // material ourselves when the node unmounts to avoid leaking it.
+  const materialRef = useRef<MeshPhongMaterial | null>(null);
+  useEffect(() => () => materialRef.current?.dispose(), []);
+
   return (
     <>
-      <a.mesh userData={{ id, type: 'node' }} scale={scale as any}>
-        <sphereGeometry attach="geometry" args={[1, 25, 25]} />
+      <a.mesh
+        userData={{ id, type: 'node' }}
+        scale={scale as any}
+        geometry={SPHERE_GEOMETRY}
+        dispose={null}
+      >
         <a.meshPhongMaterial
+          ref={materialRef as any}
           attach="material"
           side={DoubleSide}
           transparent={true}

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -1,4 +1,5 @@
 import { useThree } from '@react-three/fiber';
+import Graph from 'graphology';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { PerspectiveCamera } from 'three';
 
@@ -93,15 +94,38 @@ export const useGraph = ({
     }
   }, [storedNodes, nodes, clusterAttribute, clusters, setDrags]);
 
+  // Lazily build (and cache) the FULL graph used for collapse traversal.
+  // The store graph can't be used here — it holds the post-collapse visible
+  // subgraph. Caching by nodes/edges identity means repeated collapse/expand
+  // interactions reuse one graph instead of rebuilding it per click, and
+  // graphs that never collapse anything never build it at all.
+  const collapseGraphRef = useRef<{
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    graph: Graph;
+  } | null>(null);
+  const getCollapseGraph = useCallback(() => {
+    const cached = collapseGraphRef.current;
+    if (!cached || cached.nodes !== nodes || cached.edges !== edges) {
+      collapseGraphRef.current = {
+        nodes,
+        edges,
+        graph: buildGraph(new Graph({ multi: true }), nodes, edges)
+      };
+    }
+    return collapseGraphRef.current.graph;
+  }, [nodes, edges]);
+
   // Calculate the visible entities
   const { visibleEdges, visibleNodes } = useMemo(
     () =>
       getVisibleEntities({
         collapsedIds: stateCollapsedNodeIds,
         nodes,
-        edges
+        edges,
+        graph: stateCollapsedNodeIds?.length ? getCollapseGraph() : undefined
       }),
-    [stateCollapsedNodeIds, nodes, edges]
+    [stateCollapsedNodeIds, nodes, edges, getCollapseGraph]
   );
 
   // Store node positions inside drags state

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -13,7 +13,10 @@ import type { GraphEdge, GraphNode, InternalGraphNode } from './types';
 import { calculateClusters } from './utils/cluster';
 import { buildGraph, transformGraph } from './utils/graph';
 import type { LabelVisibilityType } from './utils/visibility';
-import { calcLabelVisibility } from './utils/visibility';
+import {
+  calcLabelVisibility,
+  isLabelVisibilityCameraDependent
+} from './utils/visibility';
 
 export interface GraphInputs {
   nodes: GraphNode[];
@@ -68,6 +71,7 @@ export const useGraph = ({
   const camera = useThree(state => state.camera) as PerspectiveCamera;
   const dragRef = useRef<DragReferences>(drags);
   const clustersRef = useRef<any>([]);
+  const prevLabelType = useRef<LabelVisibilityType | undefined>(labelType);
 
   // When a new node is added, remove the dragged position of the cluster nodes to put new node in the right place
   useEffect(() => {
@@ -196,11 +200,16 @@ export const useGraph = ({
   }, [clusters]);
 
   useEffect(() => {
+    const labelTypeChanged = prevLabelType.current !== labelType;
+    prevLabelType.current = labelType;
+
     // Camera position/zoom only affects label visibility in 'auto' mode
     // (every other mode is always-on, always-off, or shape-gated and so is
-    // camera-independent). Skipping the rest avoids an O(n) pass over every
-    // node on every camera frame.
-    if (labelType !== 'auto') {
+    // camera-independent). For those modes we still need to recompute when
+    // the labelType prop itself changes (e.g. 'all' -> 'none' at runtime),
+    // but we can skip the work on pure camera moves. This avoids an O(n)
+    // pass over every node on every camera frame.
+    if (!isLabelVisibilityCameraDependent(labelType) && !labelTypeChanged) {
       return;
     }
 

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -196,7 +196,14 @@ export const useGraph = ({
   }, [clusters]);
 
   useEffect(() => {
-    // When the camera position/zoom changes, update the label visibility.
+    // Camera position/zoom only affects label visibility in 'auto' mode
+    // (every other mode is always-on, always-off, or shape-gated and so is
+    // camera-independent). Skipping the rest avoids an O(n) pass over every
+    // node on every camera frame.
+    if (labelType !== 'auto') {
+      return;
+    }
+
     // First compute just the booleans (cheap) and only allocate a fresh
     // node array when something actually changed — this effect fires on
     // every camera move, so avoiding N object spreads per frame matters

--- a/src/useGraph.ts
+++ b/src/useGraph.ts
@@ -196,25 +196,36 @@ export const useGraph = ({
   }, [clusters]);
 
   useEffect(() => {
-    // When the camera position/zoom changes, update the label visibility
-    const nodes = stateNodes.map(node => ({
-      ...node,
-      labelVisible: calcLabelVisibility({
-        nodeCount: stateNodes?.length,
-        labelType,
-        camera,
-        nodePosition: node?.position
-      })('node', node?.size)
-    }));
+    // When the camera position/zoom changes, update the label visibility.
+    // First compute just the booleans (cheap) and only allocate a fresh
+    // node array when something actually changed — this effect fires on
+    // every camera move, so avoiding N object spreads per frame matters
+    // a lot on large graphs.
+    const getVisibility = calcLabelVisibility({
+      nodeCount: stateNodes?.length,
+      labelType,
+      camera
+    });
 
-    // Determine if the label visibility has changed
-    const isVisibilityUpdated = nodes.some(
-      (node, i) => node.labelVisible !== stateNodes[i].labelVisible
-    );
+    let isVisibilityUpdated = false;
+    const nextVisibility = new Array(stateNodes.length);
+    for (let i = 0; i < stateNodes.length; i++) {
+      const node = stateNodes[i];
+      const labelVisible = getVisibility('node', node?.size, node?.position);
+      nextVisibility[i] = labelVisible;
+      if (labelVisible !== node.labelVisible) {
+        isVisibilityUpdated = true;
+      }
+    }
 
     // Update the nodes if the label visibility has changed
     if (isVisibilityUpdated) {
-      setNodes(nodes);
+      setNodes(
+        stateNodes.map((node, i) => ({
+          ...node,
+          labelVisible: nextVisibility[i]
+        }))
+      );
     }
   }, [camera, camera.zoom, camera.position.z, setNodes, stateNodes, labelType]);
 

--- a/src/utils/visibility.ts
+++ b/src/utils/visibility.ts
@@ -16,7 +16,14 @@ export function calcLabelVisibility({
   labelType,
   camera
 }: CalcLabelVisibilityArgs) {
-  return (shape: 'node' | 'edge', size: number) => {
+  return (
+    shape: 'node' | 'edge',
+    size: number,
+    // Optional per-call position override so a single closure can be
+    // reused across many nodes instead of allocating one per node.
+    nodePositionOverride?: { x: number; y: number; z: number }
+  ) => {
+    const nodePos = nodePositionOverride ?? nodePosition;
     const isAlwaysVisible =
       labelType === 'all' ||
       (labelType === 'nodes' && shape === 'node') ||
@@ -25,8 +32,8 @@ export function calcLabelVisibility({
     if (
       !isAlwaysVisible &&
       camera &&
-      nodePosition &&
-      camera?.position?.z / camera?.zoom - nodePosition?.z > 6000
+      nodePos &&
+      camera?.position?.z / camera?.zoom - nodePos?.z > 6000
     ) {
       return false;
     }
@@ -38,8 +45,8 @@ export function calcLabelVisibility({
         return true;
       } else if (
         camera &&
-        nodePosition &&
-        camera.position.z / camera.zoom - nodePosition.z < 3000
+        nodePos &&
+        camera.position.z / camera.zoom - nodePos.z < 3000
       ) {
         return true;
       }

--- a/src/utils/visibility.ts
+++ b/src/utils/visibility.ts
@@ -4,6 +4,18 @@ import type { EdgeLabelPosition } from '../symbols';
 
 export type LabelVisibilityType = 'all' | 'auto' | 'none' | 'nodes' | 'edges';
 
+/**
+ * Whether label visibility for a given mode depends on the camera
+ * distance/zoom. Only 'auto' re-evaluates as the camera moves; every other
+ * mode is always-on, always-off, or shape-gated and therefore camera
+ * independent. Callers use this to skip per-camera-frame recomputation.
+ */
+export function isLabelVisibilityCameraDependent(
+  labelType: LabelVisibilityType
+): boolean {
+  return labelType === 'auto';
+}
+
 interface CalcLabelVisibilityArgs {
   nodeCount: number;
   nodePosition?: { x: number; y: number; z: number };


### PR DESCRIPTION
## Summary

Performance overhaul for large graphs (1k–10k+ nodes). The per-frame/per-interaction hot paths were dominated by O(n²) and O(n·e) work — every `<Node>` scanned the full node array and filtered the full edge list on each render, edges re-derived state with `Array.includes` per edge, and collapse traversal rescanned the edge list recursively. These are now O(1)/O(degree) via reactive lookup structures and graphology's native adjacency, plus GPU-side wins from shared geometry. **Public API is unchanged.**

## Measured impact (5,000 nodes / 20,000 edges, CPU harness in `perf/`)

| Hot path (per interaction/frame) | Before | After |
|---|---:|---:|
| `canCollapse` derivation × N nodes | **553 ms** | 0.1 ms |
| Edge grouping with a selection | 106 ms | 1.3 ms |
| Per-node self-lookup × N | 23.5 ms | 0.1 ms |
| Drag frame (`setNodePosition` + lookups) | ~24 ms | 0.8 ms |
| Collapse/expand interaction (50 collapsed) | ~55 ms/click | 3.0 ms |

Net: total CPU per interaction drops from ~600 ms+ of main-thread jank to ~2–3 ms; costs were quadratic before, so gains grow with graph size.

## Changes

### Store: reactive O(1) lookups (`store.ts`)
- New derived structures kept in sync with `nodes`/`edges`: `nodeMap` (id→node), `edgeMap` (id→edge), `nodesWithOutboundEdges` (Set).
- `Node`, `Edge`, the edge label overlay, `setNodePosition`, and graph centering now use them instead of `nodes.find` / `edges.filter` scans.
- `setNodePosition` is a single O(n) pass (no nested find/indexOf).

### Rendering (`symbols/`)
- One shared sphere geometry for all default nodes + cached ring geometry (was one `BufferGeometry` per node/ring) — saves tens of MB of duplicated GPU buffers at scale; uses the R3F shared-asset pattern (`dispose={null}`) with explicit per-node material disposal.
- Selection `Ring` (and its per-frame `Billboard`) only mounts when a node is selected — removes N per-frame camera-facing updates for rings that were invisible anyway. Tradeoff: deselect no longer plays a fade-out.
- `Edges`: Set-based active/inactive grouping, O(1) mesh→edge raycast lookup, and hover-set comparison by edge id (also fixes the old `Array.join()` comparison that only compared count).

### Collapse: graphology-native traversal (`collapse/`)
- `getVisibleEntities`/`getHiddenChildren`/`getExpandPath` now traverse via `graph.mapOutEdges`/`mapInEdges` (graphology's adjacency indices) instead of recursive `edges.filter` scans; hidden-set checks use `Set`s.
- The full graph is built lazily **once per nodes/edges identity** in `useGraph` and reused across collapse/expand clicks (the store graph can't be used — it holds the post-collapse subgraph). Empty `collapsedIds` short-circuits entirely.
- `useCollapse` memoizes the visible set once per input change; `getIsCollapsed` is now an O(1) Set lookup (previously re-derived the entire visible set per call).
- Same O(links·nodes) fix in the `forceInABox` layout via an id→node Map.

### Label visibility (`useGraph.ts`, `utils/visibility.ts`)
- The per-camera-frame O(n) recompute is skipped unless the mode is camera-dependent (new `isLabelVisibilityCameraDependent()` predicate in `visibility.ts`); runtime `labelType` changes still recompute immediately.
- The recompute allocates new node objects only when visibility actually changed.

## Testing
- New unit tests: store lookup invariants (4) and collapse characterization tests written against the original behavior before refactoring (chain, diamond, multi-parent, expand-path ordering, prebuilt-graph equivalence) (8).
- New CPU benchmark harness `perf/largeGraph.bench.test.ts` measuring old vs new paths at 1k/2.5k/5k nodes.
- Full suite green (62 tests), `tsc --noEmit` clean, lint clean, `build` + `build-storybook` pass.

⚠️ The geometry-sharing and ring changes touch the WebGL render path and were verified by tests/typecheck only (no GPU in the dev environment) — worth a quick visual pass over the Storybook preview (node rendering, selection rings, hover/selection on edges, collapse/expand) before merge.

https://claude.ai/code/session_01MUn7w78R3nhhMtnjPsLSdt